### PR TITLE
Fix repeated loading in the fragments demo

### DIFF
--- a/docs_site/content/advanced/html-fragments.md
+++ b/docs_site/content/advanced/html-fragments.md
@@ -103,14 +103,48 @@ Load Citry once in the host document, then insert the response:
 ```
 
 The existing runtime notices the fragment manifest, fetches missing assets,
-and activates the complete fragment. Each dependency is loaded once per page.
+and activates the complete fragment. It reuses dependencies that are still
+loaded in the page.
+
+## Render a fresh fragment for each insertion
+
+If a second insertion loses its styling or browser behavior, check whether
+the endpoint is returning the same serialized HTML. A rendered fragment that
+uses Citry's browser runtime must be inserted only once per page. Render a
+fresh fragment for each later insertion, even when the content is unchanged.
+
+Saving the serialized response and returning it on every request reuses the
+same component identities, so Citry rejects the second insertion:
+
+```python
+# Wrong: every request returns the same rendered fragment.
+saved_html = Card(title="Welcome").render().serialize(
+    deps_strategy="fragment",
+)
+
+
+def card_fragment():
+    return saved_html
+```
+
+Render inside the request handler so each response represents a new fragment:
+
+```python
+def card_fragment():
+    # Each request creates a fragment that can be inserted once.
+    return Card(title="Welcome").render().serialize(
+        deps_strategy="fragment",
+    )
+```
+
+A static demo can load its pre-rendered fragment once, then reload the host
+document to let the reader try again.
 
 ## Insert into a page without Citry
 
 A fragment can include a small loader for Citry's runtime. The browser still
 has to execute that loader. Scripts inserted through `innerHTML` stay inert,
-so the example in the previous section only works because Citry was already
-loaded.
+so the `innerHTML` example above only works because Citry was already loaded.
 
 For a runtime-free host, use a swap library that executes response scripts, or
 parse the response and recreate its `<script>` elements as live DOM nodes.

--- a/docs_site/examples/fragments/page.py
+++ b/docs_site/examples/fragments/page.py
@@ -29,23 +29,57 @@ class FragmentsPage(Component):
           <p>Load a component rendered on the server and sent as an HTML fragment:</p>
           <button
             id="frag-load"
+            type="button"
             data-fragment-url="/examples/fragments/demo/widget/"
             style="padding: 0.5rem 1rem; cursor: pointer;"
           >
             Load fragment
           </button>
+          <button
+            id="frag-reset"
+            type="button"
+            hidden
+            style="padding: 0.5rem 1rem; cursor: pointer;"
+          >
+            Reset demo
+          </button>
+          <p id="frag-status" role="status"></p>
           <div id="frag-target" style="margin-top: 1rem;"></div>
           <script>
-            document
-              .getElementById("frag-load")
-              .addEventListener("click", async (event) => {
-                const url = event.currentTarget.dataset.fragmentUrl;
+            const loadButton = document.getElementById("frag-load");
+            const resetButton = document.getElementById("frag-reset");
+            const status = document.getElementById("frag-status");
+
+            loadButton.addEventListener("click", async () => {
+              // The static response represents one render. Block repeat clicks
+              // before fetching so it can only be inserted once in this page.
+              if (loadButton.disabled) return;
+              loadButton.disabled = true;
+              status.textContent = "Loading fragment...";
+
+              let html;
+              try {
+                const url = loadButton.dataset.fragmentUrl;
                 const response = await fetch(url);
-                const html = await response.text();
-                // Inserting the fragment's manifest triggers the runtime, which
-                // loads the component scripts from static /citry/cache/ files.
-                document.getElementById("frag-target").innerHTML = html;
-              });
+                if (!response.ok) throw new Error("Fragment request failed");
+                html = await response.text();
+              } catch {
+                // A failed fetch has not inserted anything, so retry is safe.
+                status.textContent = "Could not load the fragment. Try again.";
+                loadButton.disabled = false;
+                return;
+              }
+
+              // The runtime activates the fragment after its manifests arrive.
+              document.getElementById("frag-target").innerHTML = html;
+              status.textContent = "Reset the demo to load the fragment again.";
+              resetButton.hidden = false;
+            });
+
+            resetButton.addEventListener("click", () => {
+              // A new document can accept the static fragment again.
+              window.location.reload();
+            });
           </script>
         </body>
       </html>

--- a/docs_site/tests/e2e/test_docs_e2e.py
+++ b/docs_site/tests/e2e/test_docs_e2e.py
@@ -2406,13 +2406,118 @@ def test_fragment_loads_its_deps_on_demand(page: Any, docs_site_url: str) -> Non
     # The whole static-fragment path: the page loads the runtime from /citry/,
     # a click fetches the pre-rendered fragment, the runtime loads the component's
     # JS/CSS from the static /citry/cache/ files, and the fragment's own JS runs.
+    errors: list[str] = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    page.on("console", lambda message: errors.append(message.text) if message.type == "error" else None)
     page.goto(docs_site_url + "/examples/fragments/demo/")
-    page.locator("#frag-load").click()
+    load = page.locator("#frag-load")
+    reset = page.locator("#frag-reset")
+    assert load.is_enabled()
+    assert reset.is_hidden()
+    assert page.locator(".frag-widget").count() == 0
+
+    # Hold the response so rapid clicks exercise the pending state regardless
+    # of server speed. Count fetch calls before network events can be delayed.
+    pending: list[Any] = []
+    fragment_url = docs_site_url + load.get_attribute("data-fragment-url")
+    page.route(fragment_url, lambda route: pending.append(route))
+    page.evaluate(
+        """() => {
+          const fetch = window.fetch;
+          window.fragmentFetchCount = 0;
+          window.fetch = (...args) => {
+            window.fragmentFetchCount += 1;
+            return fetch(...args);
+          };
+        }"""
+    )
+    with page.expect_request(fragment_url):
+        immediate = load.evaluate(
+            """button => {
+              button.click();
+              const disabled = button.disabled;
+              button.click();
+              button.dispatchEvent(new MouseEvent('click'));
+              return {disabled, requests: window.fragmentFetchCount};
+            }"""
+        )
+    assert immediate == {"disabled": True, "requests": 1}
+    assert len(pending) == 1
+    assert reset.is_hidden()
+    assert page.locator(".frag-widget").count() == 0
+    pending[0].continue_()
     page.wait_for_function("document.querySelector('.frag-widget')?.dataset.ready === '1'")
-    assert "(JS ran)" in page.locator(".frag-widget__title").inner_text()
     # The component's CSS loaded too (the widget got its purple border).
-    border = page.eval_on_selector(".frag-widget", "el => getComputedStyle(el).borderTopColor")
-    assert border == "rgb(130, 80, 223)"  # #8250df
+    widget = page.locator(".frag-widget")
+    assert widget.evaluate("el => getComputedStyle(el).borderTopColor") == "rgb(130, 80, 223)"  # #8250df
+    assert load.is_disabled()
+    assert reset.is_visible()
+
+    # Reusing these static bytes would replace the initialized node and lose
+    # its dependencies. Both native and synthetic later clicks must leave it intact.
+    original_widget = widget.element_handle()
+    fetch_count = page.evaluate("window.fragmentFetchCount")
+    load.evaluate(
+        """button => {
+          button.click();
+          button.dispatchEvent(new MouseEvent('click'));
+          button.dispatchEvent(new MouseEvent('click'));
+        }"""
+    )
+    assert page.evaluate("window.fragmentFetchCount") == fetch_count
+    assert len(pending) == 1
+    assert widget.evaluate("(el, original) => el === original", original_widget)
+    assert widget.get_attribute("data-ready") == "1"
+    assert widget.evaluate("el => getComputedStyle(el).borderTopColor") == "rgb(130, 80, 223)"
+
+    # A document reload makes the static fragment safe to insert again.
+    page.unroute(fragment_url)
+    with page.expect_navigation(wait_until="load"):
+        reset.click()
+    assert page.evaluate("typeof window.fragmentFetchCount") == "undefined"
+    assert load.is_enabled()
+    assert reset.is_hidden()
+    assert widget.count() == 0
+    load.click()
+    page.wait_for_function("document.querySelector('.frag-widget')?.dataset.ready === '1'")
+    assert widget.count() == 1
+    assert widget.evaluate("el => getComputedStyle(el).borderTopColor") == "rgb(130, 80, 223)"
+    assert errors == []
+
+
+@pytest.mark.parametrize("failure", ["http", "network"])
+def test_fragment_fetch_failure_allows_retry(page: Any, docs_site_url: str, failure: str) -> None:
+    page.goto(docs_site_url + "/examples/fragments/demo/")
+    load = page.locator("#frag-load")
+    fragment_url = docs_site_url + load.get_attribute("data-fragment-url")
+
+    # A response error and a rejected fetch take different browser paths, but
+    # neither inserts a fragment or consumes the user's one successful load.
+    def fail_fetch(route: Any) -> None:
+        if failure == "http":
+            route.fulfill(status=503, content_type="text/plain", body="Temporarily unavailable")
+        else:
+            route.abort()
+
+    page.route(fragment_url, fail_fetch, times=1)
+    load.click()
+    page.wait_for_function(
+        """() => !document.querySelector('#frag-load').disabled
+          && document.querySelector('#frag-status').textContent.trim().length > 0"""
+    )
+    status = page.locator("#frag-status")
+    assert status.get_attribute("role") == "status"
+    assert status.is_visible()
+    error_status = status.inner_text()
+    assert page.locator("#frag-reset").is_hidden()
+    assert page.locator("#frag-target").inner_html() == ""
+
+    load.click()
+    page.wait_for_function("document.querySelector('.frag-widget')?.dataset.ready === '1'")
+    assert page.locator(".frag-widget").count() == 1
+    assert load.is_disabled()
+    assert page.locator("#frag-reset").is_visible()
+    assert status.inner_text() != error_status
 
 
 def test_content_page_has_an_edit_on_github_link(page: Any, docs_site_url: str) -> None:


### PR DESCRIPTION
## What this does

The published fragments demo loses its styling and JavaScript behavior on a second load because its static response contains component identities that Citry accepts only once per document.

Disable loading before the request starts, preserve the loaded widget, and offer **Reset demo** to reload the document. Failed requests allow retry. Document that later insertions need a fresh server render.

Fixes #105

## Validation

- Browser coverage checks rapid and later clicks, reset, and HTTP/network failure recovery.
- Fast repository gate, Linux-targeted mypy, and docs source guards passed.
- Full repository gate (including coverage and qualification tests) passed.
- PR-worktree checks passed: three Chromium cases and the fragment rendering test.

## Checklist

- [x] Tests added or updated, and the full repository gate passes locally.
- [x] Changelog assessed: no package release note is needed for this docs-only change.
- [x] Documentation updated with fresh-render guidance.
- [x] Cross-language contract assessed: no grammar, AST, compiler, or binding changes.
