### PR TITLE
Activate published Citry 0.5.0 playground wheels

### DIFF
--- a/docs_site/static/playground/runtime.json
+++ b/docs_site/static/playground/runtime.json
@@ -8,17 +8,17 @@
     "module_url": "https://cdn.jsdelivr.net/pyodide/v314.0.3/full/pyodide.mjs"
   },
   "citry": {
-    "version": "0.4.6",
-    "core_version": "1.6.1",
-    "ui_version": "0.2.0"
+    "version": "0.5.0",
+    "core_version": "1.7.0",
+    "ui_version": "0.2.1"
   },
   "packages": [
     {
       "name": "citry-core",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "source": "pypi",
-      "filename": "citry_core-1.6.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
-      "sha256": "52e512ca1d1f279ab25c88cda30607f563f08ba4883a468b539b7aee2322bb7e"
+      "filename": "citry_core-1.7.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl",
+      "sha256": "869a4bae2f50a699b180acea527fab5117a011ede0fca65a433db6de1e2a40c1"
     },
     {
       "name": "MarkupSafe",
@@ -40,17 +40,17 @@
     },
     {
       "name": "citry",
-      "version": "0.4.6",
+      "version": "0.5.0",
       "source": "pypi",
-      "filename": "citry-0.4.6-py3-none-any.whl",
-      "sha256": "571ac6d2e5a313599e66aa863707341305cdb6f09b48e2f89ecffcda71023029"
+      "filename": "citry-0.5.0-py3-none-any.whl",
+      "sha256": "c84385f48eec4d2090c019b5c56c2bf3dd4d5d6c3751692cd10a545bb6cf6caa"
     },
     {
       "name": "citry-ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "source": "pypi",
-      "filename": "citry_ui-0.2.0-py3-none-any.whl",
-      "sha256": "e81f95e8c654f9c456f97896b2761ce2e2dad90aee95df5f19fb7069a72536ed"
+      "filename": "citry_ui-0.2.1-py3-none-any.whl",
+      "sha256": "59c06b153aeb2a2f82b12960b027dae2cd3f95cfd202906fc499075a1e5b475e"
     }
   ]
 }


### PR DESCRIPTION
Use the published Citry 0.5.0, Core 1.7.0 and Citry UI 0.2.1 wheels in the playground. Each filename and SHA-256 matches both the qualified release inventory and PyPI.

Validation: three published-runtime Chromium tests passed; independent artifact/pin review passed. Pyodide and all other dependency pins are unchanged.
