### PR TITLE
Automate protected release tags with the dedicated App

### DIFF
--- a/.github/workflows/py--citry--publish.yml
+++ b/.github/workflows/py--citry--publish.yml
@@ -248,10 +248,13 @@ jobs:
       RELEASE_COMMIT: ${{ inputs.release_commit }}
       RELEASE_TAG: citry@${{ needs.verify-version.outputs.version }}
     permissions:
-      actions: write
+      actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -331,28 +334,88 @@ jobs:
             if [ "$attempt" = 20 ]; then exit 1; fi
             sleep 5
           done
-      - name: Create or verify the final annotated tag
+      - name: Prepare the verified GitHub Release files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
+          mkdir release-closeout
+          cp dist/*.whl dist/*.tar.gz verified/release-inventory.json verified/qualification-provenance.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: citry
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: citry@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: citry@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          dist/* verified/release-inventory.json verified/qualification-provenance.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/.github/workflows/py--citry-core--publish.yml
+++ b/.github/workflows/py--citry-core--publish.yml
@@ -590,8 +590,11 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -672,28 +675,88 @@ jobs:
             if [ "$attempt" = 20 ]; then exit 1; fi
             sleep 5
           done
-      - name: Create or verify the final annotated tag
+      - name: Prepare the verified GitHub Release files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
+          mkdir release-closeout
+          cp dist/*.whl dist/*.tar.gz verified/release-inventory.json verified/qualification-provenance.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: citry-core
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: citry-core@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: citry-core@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          dist/* verified/release-inventory.json verified/qualification-provenance.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/.github/workflows/py--citry-lsp--publish.yml
+++ b/.github/workflows/py--citry-lsp--publish.yml
@@ -239,8 +239,11 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -320,28 +323,88 @@ jobs:
             if [ "$attempt" = 20 ]; then exit 1; fi
             sleep 5
           done
-      - name: Create or verify the final annotated tag
+      - name: Prepare the verified GitHub Release files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
+          mkdir release-closeout
+          cp dist/*.whl dist/*.tar.gz verified/release-inventory.json verified/qualification-provenance.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: citry-lsp
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: citry-lsp@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: citry-lsp@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          dist/* verified/release-inventory.json verified/qualification-provenance.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/.github/workflows/py--citry-ui--publish.yml
+++ b/.github/workflows/py--citry-ui--publish.yml
@@ -330,8 +330,11 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -411,28 +414,88 @@ jobs:
             if [ "$attempt" = 20 ]; then exit 1; fi
             sleep 5
           done
-      - name: Create or verify the final annotated tag
+      - name: Prepare the verified GitHub Release files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
+          mkdir release-closeout
+          cp dist/*.whl dist/*.tar.gz verified/release-inventory.json verified/qualification-provenance.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: citry-ui
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: citry-ui@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: citry-ui@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          dist/* verified/release-inventory.json verified/qualification-provenance.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/.github/workflows/py--pygments-citry--publish.yml
+++ b/.github/workflows/py--pygments-citry--publish.yml
@@ -209,8 +209,11 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -290,28 +293,88 @@ jobs:
             if [ "$attempt" = 20 ]; then exit 1; fi
             sleep 5
           done
-      - name: Create or verify the final annotated tag
+      - name: Prepare the verified GitHub Release files
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
+          mkdir release-closeout
+          cp dist/*.whl dist/*.tar.gz verified/release-inventory.json verified/qualification-provenance.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: pygments-citry
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: pygments-citry@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: pygments-citry@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          dist/* verified/release-inventory.json verified/qualification-provenance.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/.github/workflows/repo--release-tag.yml
+++ b/.github/workflows/repo--release-tag.yml
@@ -1,0 +1,55 @@
+# The caller must first publish and verify the qualified package bytes.
+name: Create the protected package tag
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        required: true
+        type: string
+      release_commit:
+        required: true
+        type: string
+      release_tag:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: release-maintenance
+    env:
+      PACKAGE: ${{ inputs.package }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate the package source and existing tag before requesting write access
+        run: >-
+          python -m scripts.release_tag validate
+          --package "$PACKAGE" --release-commit "$RELEASE_COMMIT"
+          --release-tag "$RELEASE_TAG"
+      - name: Mint the dedicated release App token
+        id: app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: citry
+          permission-contents: write
+      - name: Create or verify the final annotated tag
+        env:
+          RELEASE_APP_TOKEN: ${{ steps.app.outputs.token }}
+        run: >-
+          python -m scripts.release_tag create
+          --package "$PACKAGE" --release-commit "$RELEASE_COMMIT"
+          --release-tag "$RELEASE_TAG"

--- a/.github/workflows/vscode--citry--publish.yml
+++ b/.github/workflows/vscode--citry--publish.yml
@@ -320,8 +320,11 @@ jobs:
     permissions:
       actions: read
       attestations: write
-      contents: write
+      contents: read
       id-token: write
+    outputs:
+      closeout_id: ${{ steps.closeout.outputs.artifact-id }}
+      closeout_digest: ${{ steps.closeout.outputs.artifact-digest }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -422,17 +425,6 @@ jobs:
           done
           echo "::error::extension version did not become public in both registries"
           exit 1
-      - name: Create or verify the final annotated tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-            test "$(git rev-parse "$RELEASE_TAG^{commit}")" = "$RELEASE_COMMIT"
-          else
-            git tag -a "$RELEASE_TAG" "$RELEASE_COMMIT" -m "Release $RELEASE_TAG"
-            git push origin "refs/tags/$RELEASE_TAG"
-          fi
       - name: Attest the promotion of the qualified bytes
         uses: actions/attest-build-provenance@v4
         with:
@@ -441,20 +433,88 @@ jobs:
             verified/release-inventory.json
             verified/qualification-provenance.json
             verified/registry-verification.json
+      - name: Prepare the verified GitHub Release files
+        run: |
+          mkdir release-closeout
+          cp verified/*.vsix verified/release-inventory.json verified/qualification-provenance.json verified/registry-verification.json release-closeout/
+      - name: Retain the verified release files for closeout
+        id: closeout
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-closeout-${{ github.run_attempt }}
+          path: release-closeout/*
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    name: Create or verify the final annotated tag
+    needs: [verify-version, release]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/repo--release-tag.yml
+    with:
+      package: vscode-citry
+      release_commit: ${{ inputs.release_commit }}
+      release_tag: vscode-citry@${{ needs.verify-version.outputs.version }}
+
+  closeout:
+    name: Create the GitHub Release and notify
+    needs: [verify-version, release, tag]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    env:
+      RELEASE_TAG: vscode-citry@${{ needs.verify-version.outputs.version }}
+      RELEASE_COMMIT: ${{ inputs.release_commit }}
+      RELEASE_VERSION: ${{ needs.verify-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Download the exact verified closeout archive
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.release.outputs.closeout_id }}
+        run: |
+          curl --fail --location --silent --show-error \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/actions/artifacts/$ARTIFACT_ID/zip" \
+            --output closeout.zip
+      - name: Verify the transferred release files
+        env:
+          ARTIFACT_DIGEST: ${{ needs.release.outputs.closeout_digest }}
+        run: >-
+          python -m scripts.release_closeout
+          --archive closeout.zip --artifact-digest "$ARTIFACT_DIGEST"
+          --release-commit "$RELEASE_COMMIT" --version "$RELEASE_VERSION"
+          --output-dir release-assets
+      - name: Verify existing GitHub Release state
+        id: public-state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --github-output "$GITHUB_OUTPUT"
       - name: Create the GitHub Release
         if: steps.public-state.outputs.release_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
-          gh release create "$RELEASE_TAG"
-          verified/*.vsix
-          verified/release-inventory.json
-          verified/qualification-provenance.json
-          verified/registry-verification.json
-          --repo "$GITHUB_REPOSITORY"
-          --title "$RELEASE_TAG"
-          --verify-tag
-          --generate-notes
+          gh release create "$RELEASE_TAG" release-assets/*
+          --repo "$GITHUB_REPOSITORY" --title "$RELEASE_TAG"
+          --verify-tag --generate-notes
+      - name: Verify the completed GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python -m scripts.verify_github_release
+          --repository "$GITHUB_REPOSITORY" --tag "$RELEASE_TAG"
+          --assets-dir release-assets --require-existing
       - name: Start the Discord release notification
         if: steps.public-state.outputs.release_exists != 'true'
         env:

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -409,7 +409,7 @@ python scripts/check.py --profile full
 python scripts/check.py --profile fast --reporter agent
 
 # Run only the custom validators (fast; no compiling or tests).
-python scripts/validate.py
+uv run --no-sync python scripts/validate.py
 ```
 
 `check.py` only checks; it never edits files. It assumes the workspace is set

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -1404,15 +1404,46 @@ for publication jobs. Environment restrictions are configured in GitHub
 settings, outside workflow files. Permission to use an environment is separate
 from permission to update `main` or create a release tag.
 
-The current protected tag rules grant creation to the maintainer account, not
-the default Actions token. If a publication worker stops at tag creation after
-verifying public files, the authorized maintainer verifies the full public
-inventory against the candidate, creates the annotated tag at the candidate's
-exact commit, and restarts the controller with the same candidate ID. Existing
-public files must match exactly; never rebuild or replace them during recovery.
-A dedicated release identity needs its own narrowly scoped tag permission before
-these protected-tag releases can complete unattended. Track that decision in
-[issue 46](https://github.com/citry-dev/citry/issues/46).
+Package publication, tag creation, and GitHub Release creation run in separate
+jobs. The publication job verifies the exact public bytes and retains its release
+files as an immutable Actions artifact. A reusable job then uses the release App
+in `release-maintenance` to create the package's annotated tag. It reads the
+package version from the qualified source commit, requires that commit to remain
+on `main`, and executes only the current trusted workflow's helper code. The App
+key is available only in this tag job and the generated-site write job.
+
+Tag creation protection covers all six package namespaces and allows only the
+release App to create tags. A separate rule blocks tag updates and deletion
+without bypass actors. An existing annotated tag pointing at the expected commit
+is accepted. A lightweight tag, different target, or network failure stops the
+job. The helper never moves, deletes, or force-pushes a tag.
+
+After tag creation, a fresh job verifies the transferred artifact digest, file
+inventory and qualified commit before attaching those files to the GitHub
+Release. It uses the ordinary Actions token and has neither publishing credentials
+nor the release App key. It sends a Discord notification only for a newly created
+Release. A failure after publication can be recovered by rerunning the controller
+with the same candidate: public packages must still match exactly, and matching
+annotated tags and complete Releases with byte-matching assets are accepted. A
+draft, incomplete or mismatched Release stops for deliberate reconciliation; the
+workflow does not overwrite it. Existing Python Releases may also contain publish
+attestation files: these are accepted only when their bytes match GitHub metadata,
+their contents match PyPI provenance, and they identify the expected package file
+and digest. Recover a failed Discord notification through its own workflow after
+the Release exists.
+
+The publishing environments permit only the exact `main` branch, with no tag
+allowances. The `release_security` validator checks job dependencies, fixed
+publishing environments, trusted helper checkout refs, artifact verification and
+App-key placement. This detects mistakes in reviewed workflow changes; the GitHub
+environment policies are the independent boundary against modified branch
+workflows. Recheck those external policies and App permissions after changing the
+release process.
+
+Independent PR and deployment approvals will be enabled when the maintainer team
+grows; [issue 112](https://github.com/citry-dev/citry/issues/112) tracks that change.
+The current sole-maintainer process requires no second approver. Administrator
+control over repository settings remains an explicit trust boundary.
 
 ### The `review` branch holds work that has not been read yet
 

--- a/packages/py/citry/tests/test_github_release_state.py
+++ b/packages/py/citry/tests/test_github_release_state.py
@@ -1,0 +1,273 @@
+"""Publication reuses only complete releases whose assets match verified bytes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import urllib.error
+from email.message import Message
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from scripts.verify_github_release import (
+    GitHubReleaseError,
+    _HTTPSRedirect,
+    _NoRedirect,
+    _public_bytes,
+    _verify_attestation,
+    fetch_release,
+    main,
+    verify_release,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TAG = "citry@0.5.0"
+PLACEHOLDER = "test-token"
+
+
+def _release(tmp_path: Path) -> dict[str, Any]:
+    (tmp_path / "approved.whl").write_bytes(b"approved")
+    return {
+        "draft": False,
+        "tag_name": TAG,
+        "assets": [
+            {
+                "name": "approved.whl",
+                "size": 8,
+                "digest": "sha256:" + hashlib.sha256(b"approved").hexdigest(),
+                "state": "uploaded",
+            }
+        ],
+    }
+
+
+def test_accepts_exact_existing_release(tmp_path: Path) -> None:
+    assert verify_release(status=200, payload=_release(tmp_path), tag=TAG, assets_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "change", ["draft", "tag", "missing", "extra", "size", "digest", "no_digest", "duplicate", "state"]
+)
+def test_rejects_incomplete_or_different_release(tmp_path: Path, change: str) -> None:
+    release = _release(tmp_path)
+    asset = release["assets"][0]
+    if change == "draft":
+        release["draft"] = True
+    elif change == "tag":
+        release["tag_name"] = "citry@0.4.0"
+    elif change == "missing":
+        release["assets"] = []
+    elif change == "extra":
+        release["assets"].append({**asset, "name": "extra.whl"})
+    elif change == "size":
+        asset["size"] += 1
+    elif change == "digest":
+        asset["digest"] = "sha256:" + "0" * 64
+    elif change == "no_digest":
+        del asset["digest"]
+    elif change == "duplicate":
+        release["assets"].append(asset)
+    else:
+        asset["state"] = "starter"
+    with pytest.raises(GitHubReleaseError, match="manually"):
+        verify_release(status=200, payload=release, tag=TAG, assets_dir=tmp_path)
+
+
+def test_missing_release_is_allowed_only_before_creation(tmp_path: Path) -> None:
+    assert not verify_release(status=404, payload=None, tag=TAG, assets_dir=tmp_path)
+    with pytest.raises(GitHubReleaseError, match="does not exist"):
+        verify_release(status=404, payload=None, tag=TAG, assets_dir=tmp_path, require_existing=True)
+
+
+@pytest.mark.parametrize("status", [301, 401, 403, 429, 500])
+def test_rejects_unexpected_http_status(tmp_path: Path, status: int) -> None:
+    with pytest.raises(GitHubReleaseError, match=f"HTTP {status}"):
+        verify_release(status=status, payload=None, tag=TAG, assets_dir=tmp_path)
+
+
+def test_api_uses_fixed_host_and_refuses_redirects() -> None:
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.status = 200
+    response.read.return_value = b'{"draft": false}'
+    with patch("scripts.verify_github_release.urllib.request.build_opener") as build:
+        build.return_value.open.return_value = response
+        assert fetch_release(repository="citry-dev/citry", tag=TAG, token=PLACEHOLDER) == (200, {"draft": False})
+        handler = build.call_args.args[0]
+        assert isinstance(handler, _NoRedirect)
+        handler.redirect_request(None, None, 302, "", {}, "https://other.example")
+        request = build.return_value.open.call_args.args[0]
+        assert request.full_url == "https://api.github.com/repos/citry-dev/citry/releases/tags/citry%400.5.0"
+
+
+@pytest.mark.parametrize("status", [302, 403, 404, 500])
+def test_api_http_errors(status: int) -> None:
+    error = urllib.error.HTTPError("https://api.github.com/", status, "error", Message(), io.BytesIO())
+    with patch("scripts.verify_github_release.urllib.request.build_opener") as build:
+        build.return_value.open.side_effect = error
+        if status == 404:
+            assert fetch_release(repository="citry-dev/citry", tag=TAG, token=PLACEHOLDER) == (404, None)
+        else:
+            with pytest.raises(GitHubReleaseError, match=f"HTTP {status}"):
+                fetch_release(repository="citry-dev/citry", tag=TAG, token=PLACEHOLDER)
+
+
+def test_api_network_error_does_not_expose_credentials() -> None:
+    with patch("scripts.verify_github_release.urllib.request.build_opener") as build:
+        build.return_value.open.side_effect = urllib.error.URLError("sensitive detail")
+        with pytest.raises(GitHubReleaseError, match=r"^GitHub release lookup failed$"):
+            fetch_release(repository="citry-dev/citry", tag=TAG, token=PLACEHOLDER)
+
+
+def test_cli_outputs_success_only_after_verification(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    release = _release(assets)
+    output = tmp_path / "output"
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+    args = [
+        "--repository",
+        "citry-dev/citry",
+        "--tag",
+        TAG,
+        "--assets-dir",
+        str(assets),
+        "--github-output",
+        str(output),
+    ]
+    with patch("scripts.verify_github_release.fetch_release", return_value=(200, release)):
+        assert main(args) == 0
+    assert output.read_text() == "release_exists=true\n"
+    release["draft"] = True
+    with patch("scripts.verify_github_release.fetch_release", return_value=(200, release)):
+        assert main(args) == 1
+    assert output.read_text() == "release_exists=true\n"
+
+
+def test_api_rejects_nonobject_json() -> None:
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.status = 200
+    response.read.return_value = json.dumps([]).encode()
+    with patch("scripts.verify_github_release.urllib.request.build_opener") as build:
+        build.return_value.open.return_value = response
+        with pytest.raises(GitHubReleaseError, match="object"):
+            fetch_release(repository="citry-dev/citry", tag=TAG, token=PLACEHOLDER)
+
+
+def _attestation() -> dict[str, Any]:
+    statement = {
+        "subject": [{"name": "approved.whl", "digest": {"sha256": hashlib.sha256(b"approved").hexdigest()}}],
+        "predicateType": "https://docs.pypi.org/attestations/publish/v1",
+    }
+    return {"version": 1, "envelope": {"statement": base64.b64encode(json.dumps(statement).encode()).decode()}}
+
+
+@pytest.mark.parametrize(
+    "change",
+    ["none", "different_provenance", "different_subject", "different_bytes", "wrong_publisher", "missing_provenance"],
+)
+def test_extra_attestation_must_match_pypi_and_approved_bytes(tmp_path: Path, change: str) -> None:
+    release = _release(tmp_path)
+    attestation = _attestation()
+    if change == "different_subject":
+        statement = json.loads(base64.b64decode(attestation["envelope"]["statement"]))
+        statement["subject"][0]["digest"]["sha256"] = "0" * 64
+        attestation["envelope"]["statement"] = base64.b64encode(json.dumps(statement).encode()).decode()
+    data = json.dumps(attestation).encode()
+    release["assets"].append(
+        {
+            "name": "approved.whl.publish.attestation",
+            "size": len(data),
+            "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+            "state": "uploaded",
+        }
+    )
+    provenance = {
+        "attestation_bundles": [
+            {
+                "attestations": [attestation] if change != "different_provenance" else [],
+                "publisher": {"repository": "elsewhere/repo" if change == "wrong_publisher" else "citry-dev/citry"},
+            }
+        ]
+    }
+    downloads: list[bytes | Exception] = [data, json.dumps(provenance).encode()]
+    if change == "different_bytes":
+        downloads[0] = b"different"
+    elif change == "missing_provenance":
+        downloads[1] = GitHubReleaseError("could not download public release metadata")
+    with patch("scripts.verify_github_release._public_bytes", side_effect=downloads) as download:
+        if change == "none":
+            assert verify_release(
+                status=200, payload=release, tag=TAG, assets_dir=tmp_path, repository="citry-dev/citry"
+            )
+            assert download.call_args_list[0].args == (
+                "https://github.com/citry-dev/citry/releases/download/citry%400.5.0/approved.whl.publish.attestation",
+            )
+            assert download.call_args_list[1].args == (
+                "https://pypi.org/integrity/citry/0.5.0/approved.whl/provenance",
+            )
+        else:
+            with pytest.raises(GitHubReleaseError):
+                verify_release(status=200, payload=release, tag=TAG, assets_dir=tmp_path, repository="citry-dev/citry")
+
+
+def test_attestation_exception_is_not_available_for_vscode(tmp_path: Path) -> None:
+    release = _release(tmp_path)
+    release["tag_name"] = "vscode-citry@0.1.3"
+    data = json.dumps(_attestation()).encode()
+    release["assets"].append(
+        {
+            "name": "approved.whl.publish.attestation",
+            "size": len(data),
+            "digest": "sha256:" + hashlib.sha256(data).hexdigest(),
+            "state": "uploaded",
+        }
+    )
+    with pytest.raises(GitHubReleaseError, match="known PyPI"):
+        verify_release(
+            status=200, payload=release, tag="vscode-citry@0.1.3", assets_dir=tmp_path, repository="citry-dev/citry"
+        )
+
+
+def test_public_download_sends_no_token_and_requires_https_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", PLACEHOLDER)
+    response = MagicMock()
+    response.__enter__.return_value = response
+    response.status = 200
+    response.read.return_value = b"public bytes"
+    with patch("scripts.verify_github_release.urllib.request.build_opener") as build:
+        build.return_value.open.return_value = response
+        assert _public_bytes("https://github.com/public/file") == b"public bytes"
+        assert build.return_value.open.call_args.args == ("https://github.com/public/file",)
+        handler = build.call_args.args[0]
+        assert isinstance(handler, _HTTPSRedirect)
+        with pytest.raises(GitHubReleaseError, match="outside HTTPS"):
+            handler.redirect_request(None, None, 302, "", {}, "http://untrusted.example")
+
+
+@pytest.mark.parametrize("version", [True, 1.0])
+def test_attestation_comparison_preserves_json_value_types(version: bool | float) -> None:
+    published = _attestation()
+    sidecar = {**published, "version": version}
+    data = json.dumps(sidecar).encode()
+    provenance = {
+        "attestation_bundles": [{"attestations": [published], "publisher": {"repository": "citry-dev/citry"}}]
+    }
+    with (
+        patch("scripts.verify_github_release._public_bytes", side_effect=[data, json.dumps(provenance).encode()]),
+        pytest.raises(GitHubReleaseError, match="does not match PyPI provenance"),
+    ):
+        _verify_attestation(
+            repository="citry-dev/citry",
+            tag=TAG,
+            name="approved.whl.publish.attestation",
+            parent_digest="sha256:" + hashlib.sha256(b"approved").hexdigest(),
+            size=len(data),
+            digest="sha256:" + hashlib.sha256(data).hexdigest(),
+        )

--- a/packages/py/citry/tests/test_release_closeout.py
+++ b/packages/py/citry/tests/test_release_closeout.py
@@ -1,0 +1,174 @@
+"""Release jobs accept only the exact files verified by the publication job."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import stat
+import zipfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+from scripts.release_closeout import ReleaseCloseoutError, extract_closeout, main
+
+COMMIT = "a" * 40
+PAYLOAD = b"qualified wheel bytes"
+
+
+def _files() -> dict[str, bytes]:
+    return {
+        "release-inventory.json": json.dumps(
+            {
+                "version": "0.5.0",
+                "artifacts": [
+                    {"name": "citry.whl", "bytes": len(PAYLOAD), "sha256": hashlib.sha256(PAYLOAD).hexdigest()}
+                ],
+            }
+        ).encode(),
+        "qualification-provenance.json": json.dumps({"head_sha": COMMIT}).encode(),
+        "citry.whl": PAYLOAD,
+    }
+
+
+def _archive(tmp_path: Path, files: dict[str, bytes], extra: zipfile.ZipInfo | None = None) -> Path:
+    path = tmp_path / "closeout.zip"
+    with zipfile.ZipFile(path, "w") as target:
+        for name, payload in files.items():
+            target.writestr(name, payload)
+        if extra is not None:
+            target.writestr(extra, b"untrusted")
+    return path
+
+
+def _extract(path: Path, output: Path, digest: str | None = None) -> None:
+    extract_closeout(
+        archive=path,
+        artifact_digest=digest or hashlib.sha256(path.read_bytes()).hexdigest(),
+        release_commit=COMMIT,
+        expected_version="0.5.0",
+        output_dir=output,
+    )
+
+
+def test_extracts_exact_approved_files(tmp_path: Path) -> None:
+    files = _files()
+    archive = _archive(tmp_path, files)
+    output = tmp_path / "assets"
+    output.mkdir()
+    _extract(archive, output, "sha256:" + hashlib.sha256(archive.read_bytes()).hexdigest())
+    assert {path.name: path.read_bytes() for path in output.iterdir()} == files
+
+
+@pytest.mark.parametrize("change", ["hash", "size", "commit", "version", "extra", "missing", "duplicate", "invalid"])
+def test_rejects_changed_inventory_or_members(tmp_path: Path, change: str) -> None:
+    files = _files()
+    inventory = json.loads(files["release-inventory.json"])
+    if change == "hash":
+        files["citry.whl"] = b"x" * len(PAYLOAD)
+    elif change == "size":
+        inventory["artifacts"][0]["bytes"] += 1
+    elif change == "commit":
+        files["qualification-provenance.json"] = json.dumps({"head_sha": "b" * 40}).encode()
+    elif change == "version":
+        inventory["version"] = "0.6.0"
+    elif change == "extra":
+        files["unapproved.whl"] = b"extra"
+    elif change == "missing":
+        del files["citry.whl"]
+    elif change == "duplicate":
+        inventory["artifacts"] *= 2
+    else:
+        inventory["artifacts"][0]["bytes"] = True
+    files["release-inventory.json"] = json.dumps(inventory).encode()
+    archive = _archive(tmp_path, files)
+    with pytest.raises(ReleaseCloseoutError):
+        _extract(archive, tmp_path / "assets")
+    assert not (tmp_path / "assets").exists()
+
+
+@pytest.mark.parametrize("name", ["../outside", "/absolute", "nested/file", "back\\slash", "folder/", "-option.whl"])
+def test_rejects_unsafe_names(tmp_path: Path, name: str) -> None:
+    archive = _archive(tmp_path, _files(), zipfile.ZipInfo(name))
+    with pytest.raises(ReleaseCloseoutError, match="unsafe"):
+        _extract(archive, tmp_path / "assets")
+
+
+@pytest.mark.parametrize("mode", [stat.S_IFLNK, stat.S_IFIFO, stat.S_IFCHR, stat.S_IFDIR])
+def test_rejects_nonregular_members(tmp_path: Path, mode: int) -> None:
+    member = zipfile.ZipInfo("special.whl")
+    member.create_system = 3
+    member.external_attr = (mode | 0o600) << 16
+    archive = _archive(tmp_path, _files(), member)
+    with pytest.raises(ReleaseCloseoutError, match="unsafe"):
+        _extract(archive, tmp_path / "assets")
+
+
+def test_rejects_duplicate_zip_names(tmp_path: Path) -> None:
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        archive = _archive(tmp_path, _files(), zipfile.ZipInfo("citry.whl"))
+    with pytest.raises(ReleaseCloseoutError, match="duplicate"):
+        _extract(archive, tmp_path / "assets")
+
+
+def test_rejects_wrong_archive_digest(tmp_path: Path) -> None:
+    archive = _archive(tmp_path, _files())
+    with pytest.raises(ReleaseCloseoutError, match="archive digest"):
+        _extract(archive, tmp_path / "assets", "0" * 64)
+
+
+def test_corrupt_zip_fails_cli_without_creating_output(tmp_path: Path) -> None:
+    archive = tmp_path / "broken.zip"
+    archive.write_bytes(b"not a zip")
+    output = tmp_path / "assets"
+    assert (
+        main(
+            [
+                "--archive",
+                str(archive),
+                "--artifact-digest",
+                hashlib.sha256(archive.read_bytes()).hexdigest(),
+                "--release-commit",
+                COMMIT,
+                "--version",
+                "0.5.0",
+                "--output-dir",
+                str(output),
+            ]
+        )
+        == 1
+    )
+    assert not output.exists()
+
+
+def test_preserves_existing_output(tmp_path: Path) -> None:
+    archive = _archive(tmp_path, _files())
+    output = tmp_path / "assets"
+    output.mkdir()
+    marker = output / "existing"
+    marker.write_text("keep")
+    with pytest.raises(ReleaseCloseoutError, match="new or empty"):
+        _extract(archive, output)
+    assert marker.read_text() == "keep"
+
+
+@pytest.mark.parametrize("verified", [False, True])
+def test_vsix_requires_registry_verification(tmp_path: Path, verified: bool) -> None:
+    files = _files()
+    files["extension.vsix"] = files.pop("citry.whl")
+    inventory = json.loads(files["release-inventory.json"])
+    inventory["artifacts"][0]["name"] = "extension.vsix"
+    files["release-inventory.json"] = json.dumps(inventory).encode()
+    if verified:
+        files["registry-verification.json"] = b'{"verified": true}'
+    archive = _archive(tmp_path, files)
+    output = tmp_path / "assets"
+    if verified:
+        _extract(archive, output)
+        assert (output / "extension.vsix").read_bytes() == PAYLOAD
+    else:
+        with pytest.raises(ReleaseCloseoutError, match="require registry verification"):
+            _extract(archive, output)
+        assert not output.exists()

--- a/packages/py/citry/tests/test_release_security_policy.py
+++ b/packages/py/citry/tests/test_release_security_policy.py
@@ -1,0 +1,70 @@
+"""Publishing policy rejects changes that cross the release credential boundary."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from scripts.validators.release_security import check
+
+
+@pytest.fixture
+def workflows(tmp_path):
+    source = Path(__file__).resolve().parents[4] / ".github/workflows"
+    shutil.copytree(source, tmp_path / ".github/workflows")
+    return tmp_path
+
+
+def _change(root, filename, edit):
+    path = root / ".github/workflows" / filename
+    value = yaml.safe_load(path.read_text())
+    edit(value)
+    path.write_text(yaml.safe_dump(value))
+
+
+def test_current_workflows_pass(workflows):
+    assert check(workflows) == []
+
+
+def test_tag_cannot_run_before_publication(workflows):
+    _change(workflows, "py--citry--publish.yml", lambda value: value["jobs"]["tag"].update(needs=["verify-version"]))
+    assert any("only after verified publication" in error for error in check(workflows))
+
+
+def test_qualification_cannot_use_publish_environment(workflows):
+    _change(workflows, "py--citry--publish.yml", lambda value: value["jobs"]["build"].update(environment="pypi"))
+    assert any("outside its publication job" in error for error in check(workflows))
+
+
+def test_tag_cannot_execute_historical_release_code(workflows):
+    _change(
+        workflows,
+        "repo--release-tag.yml",
+        lambda value: value["jobs"]["tag"]["steps"][0]["with"].update(ref="${{ inputs.release_commit }}"),
+    )
+    assert any("trusted workflow source" in error for error in check(workflows))
+
+
+def test_publisher_cannot_read_release_app_key(workflows):
+    _change(
+        workflows,
+        "py--citry--publish.yml",
+        lambda value: value["jobs"]["release"].update(env={"KEY": "${{ secrets.RELEASE_APP_PRIVATE_KEY }}"}),
+    )
+    assert any("outside its isolated write job" in error for error in check(workflows))
+
+
+def test_tag_cannot_expose_a_workflow_dispatch_trigger(workflows):
+    _change(workflows, "repo--release-tag.yml", lambda value: value[True].update(workflow_dispatch={}))
+    assert any("only workflow_call" in error for error in check(workflows))
+
+
+def test_unregistered_workflow_cannot_create_protected_tags(workflows):
+    path = workflows / ".github/workflows/unregistered.yml"
+    path.write_text(yaml.safe_dump({"jobs": {"tag": {"uses": "./.github/workflows/repo--release-tag.yml"}}}))
+    assert any("outside the package publishers" in error for error in check(workflows))
+
+
+def test_tag_cannot_ignore_failed_publication(workflows):
+    _change(workflows, "py--citry--publish.yml", lambda value: value["jobs"]["tag"].update({"if": "always()"}))
+    assert any("successful dependencies" in error for error in check(workflows))

--- a/packages/py/citry/tests/test_release_tag.py
+++ b/packages/py/citry/tests/test_release_tag.py
@@ -1,0 +1,215 @@
+"""Exercise immutable package tags against a local Git remote."""
+
+import shutil
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from scripts import release_tag
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        [shutil.which("git") or "/usr/bin/git", *args], cwd=repo, text=True, capture_output=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repository(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str]:
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    git(tmp_path, "init", "--bare", str(remote))
+    git(tmp_path, "init", "-b", "main", str(repo))
+    git(repo, "config", "user.name", "Release tests")
+    git(repo, "config", "user.email", "release@example.test")
+    manifest = repo / "packages/py/citry/pyproject.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('[project]\nversion = "1.2.3"\n')
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "Initial package")
+    git(repo, "remote", "add", "origin", str(remote))
+    git(repo, "push", "origin", "main")
+    monkeypatch.setenv("RELEASE_APP_TOKEN", "synthetic-test-token")
+    return repo, git(repo, "rev-parse", "HEAD")
+
+
+def test_create_and_retry(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    assert not release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+    release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    first = git(repo, "rev-parse", "citry@1.2.3")
+    release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    assert git(repo, "cat-file", "-t", first) == "tag"
+    assert git(repo, "rev-parse", "citry@1.2.3") == first
+
+
+@pytest.mark.parametrize(
+    ("package", "sha", "tag"),
+    [
+        ("unknown", None, "citry@1.2.3"),
+        ("citry", "abc", "citry@1.2.3"),
+        ("citry", None, "citry@1.2.4"),
+        ("citry", None, "refs/heads/main"),
+    ],
+)
+def test_invalid_identity(repository: tuple[Path, str], package: str, sha: str | None, tag: str) -> None:
+    repo, commit = repository
+    with pytest.raises(release_tag.ReleaseTagError):
+        release_tag.validate(repo, package, sha or commit, tag)
+
+
+def test_unmerged_commit(repository: tuple[Path, str]) -> None:
+    repo, _ = repository
+    git(repo, "commit", "--allow-empty", "-m", "Unpublished work")
+    with pytest.raises(release_tag.ReleaseTagError, match="merge-base"):
+        release_tag.validate(repo, "citry", git(repo, "rev-parse", "HEAD"), "citry@1.2.3")
+
+
+def test_lightweight_tag(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    git(repo, "tag", "citry@1.2.3", commit)
+    git(repo, "push", "origin", "refs/tags/citry@1.2.3")
+    with pytest.raises(release_tag.ReleaseTagError, match="not annotated"):
+        release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+
+
+def test_wrong_tag_target(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    git(repo, "commit", "--allow-empty", "-m", "Later work")
+    git(repo, "tag", "-a", "citry@1.2.3", "-m", "Wrong target")
+    git(repo, "push", "origin", "refs/tags/citry@1.2.3")
+    with pytest.raises(release_tag.ReleaseTagError, match="different commit"):
+        release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+
+
+def test_remote_error_is_not_absence(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    original = release_tag._git
+
+    def failed_query(path: Path, *args: str, authenticated: bool = False) -> subprocess.CompletedProcess[str]:
+        if args[0] == "ls-remote":
+            return subprocess.CompletedProcess(args, 128, "", "network failure")
+        return original(path, *args, authenticated=authenticated)
+
+    with (
+        patch.object(release_tag, "_git", side_effect=failed_query),
+        pytest.raises(
+            release_tag.ReleaseTagError,
+            match="query the remote",
+        ),
+    ):
+        release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    assert not git(repo, "tag", "--list")
+
+
+def test_concurrent_identical_creation(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    original = release_tag._git
+
+    def race(path: Path, *args: str, authenticated: bool = False) -> subprocess.CompletedProcess[str]:
+        result = original(path, *args, authenticated=authenticated)
+        if args[0] == "push":
+            assert result.returncode == 0
+            return subprocess.CompletedProcess(args, 1, "", "concurrent writer won")
+        return result
+
+    with patch.object(release_tag, "_git", side_effect=race):
+        release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    assert release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+
+
+def test_failed_push_is_not_success(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    original = release_tag._git
+
+    def failed_push(path: Path, *args: str, authenticated: bool = False) -> subprocess.CompletedProcess[str]:
+        if args[0] == "push":
+            return subprocess.CompletedProcess(args, 1, "", "permission denied")
+        return original(path, *args, authenticated=authenticated)
+
+    with (
+        patch.object(release_tag, "_git", side_effect=failed_push),
+        pytest.raises(
+            release_tag.ReleaseTagError,
+            match="push failed",
+        ),
+    ):
+        release_tag.create(repo, "citry", commit, "citry@1.2.3")
+
+
+@pytest.mark.parametrize("package", sorted(release_tag.PACKAGE_BY_KEY))
+def test_package_manifest_mapping(repository: tuple[Path, str], package: str) -> None:
+    repo, _ = repository
+    spec = release_tag.PACKAGE_BY_KEY[package]
+    manifest = repo / spec.manifest
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text('{"version": "2.3.4"}' if spec.manifest_kind == "json" else '[project]\nversion = "2.3.4"\n')
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "Selected package")
+    git(repo, "push", "origin", "main")
+    commit = git(repo, "rev-parse", "HEAD")
+    release_tag.create(repo, package, commit, f"{spec.tag_prefix}2.3.4")
+    assert release_tag.validate(repo, package, commit, f"{spec.tag_prefix}2.3.4")
+
+
+@pytest.mark.parametrize("version", ['"01.2.3"', '"1.2"', "123", '"1.2.3/injected"'])
+def test_invalid_manifest_version(repository: tuple[Path, str], version: str) -> None:
+    repo, _ = repository
+    (repo / "packages/py/citry/pyproject.toml").write_text(f"[project]\nversion = {version}\n")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "Invalid manifest")
+    git(repo, "push", "origin", "main")
+    with pytest.raises(release_tag.ReleaseTagError, match="version is invalid"):
+        release_tag.validate(repo, "citry", git(repo, "rev-parse", "HEAD"), "citry@1.2.3")
+
+
+def test_missing_credential(repository: tuple[Path, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, commit = repository
+    monkeypatch.delenv("RELEASE_APP_TOKEN")
+    with pytest.raises(release_tag.ReleaseTagError, match="TOKEN is missing"):
+        release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    assert not release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+
+
+def test_remote_fetch_failure(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    original = release_tag._git
+
+    def failed_fetch(path: Path, *args: str, authenticated: bool = False) -> subprocess.CompletedProcess[str]:
+        if args[0] == "fetch" and args[-1].startswith("refs/tags/"):
+            return subprocess.CompletedProcess(args, 128, "", "network failure")
+        return original(path, *args, authenticated=authenticated)
+
+    with (
+        patch.object(release_tag, "_git", side_effect=failed_fetch),
+        pytest.raises(
+            release_tag.ReleaseTagError,
+            match="git fetch failed",
+        ),
+    ):
+        release_tag.validate(repo, "citry", commit, "citry@1.2.3")
+
+
+def test_tag_object_sha_is_not_a_release_commit(repository: tuple[Path, str]) -> None:
+    repo, commit = repository
+    git(repo, "tag", "-a", "source-alias", commit, "-m", "Source alias")
+    tag_object = git(repo, "rev-parse", "source-alias")
+    with pytest.raises(release_tag.ReleaseTagError, match="must name a commit object"):
+        release_tag.create(repo, "citry", tag_object, "citry@1.2.3")
+    assert not git(repo, "ls-remote", "--tags", "origin", "refs/tags/citry@1.2.3")
+    assert not git(repo, "tag", "--list", "citry@1.2.3")
+
+
+@pytest.mark.parametrize("remote", [False, True])
+def test_annotation_internal_name_must_match(repository: tuple[Path, str], remote: bool) -> None:
+    repo, commit = repository
+    git(repo, "tag", "-a", "different-release", commit, "-m", "Different release")
+    git(repo, "update-ref", "refs/tags/citry@1.2.3", git(repo, "rev-parse", "different-release"))
+    if remote:
+        git(repo, "push", "origin", "refs/tags/citry@1.2.3")
+    with pytest.raises(release_tag.ReleaseTagError, match="different internal identity"):
+        release_tag.create(repo, "citry", commit, "citry@1.2.3")
+    if not remote:
+        assert not git(repo, "ls-remote", "--tags", "origin", "refs/tags/citry@1.2.3")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "maturin>=1.10.2",
     "ruff>=0.10.0",
     "mypy>=1.0.0",
+    "pyyaml>=6.0",
     # Repository scripts parse package manifests on Python 3.10.
     "tomli>=2.0; python_version < '3.11'",
 ]

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -199,7 +199,7 @@ def _phases(profile: CheckProfile = "full") -> list[tuple[str, list[str]]]:
         # but tracing them makes their run several times slower without adding
         # useful coverage. The version matrix also runs them without coverage.
         *([("pytest qualification", _qualification_pytest_command())] if profile == "full" else []),
-        ("validators", [sys.executable, "scripts/validate.py"]),
+        ("validators", [*uvr, "python", "scripts/validate.py"]),
     ]
 
 

--- a/scripts/release_closeout.py
+++ b/scripts/release_closeout.py
@@ -1,0 +1,128 @@
+"""Verify publisher files before attaching them to a GitHub Release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import stat
+import sys
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class ReleaseCloseoutError(ValueError):
+    """The downloaded files do not match the publication job's verified archive."""
+
+
+def _object(data: bytes, name: str) -> dict[str, Any]:
+    value = json.loads(data)
+    if not isinstance(value, dict):
+        raise ReleaseCloseoutError(f"{name} must contain an object")
+    return value
+
+
+def extract_closeout(
+    *, archive: Path, artifact_digest: str, release_commit: str, expected_version: str, output_dir: Path
+) -> None:
+    """Check the complete archive, then write its files to an empty directory."""
+    digest = artifact_digest.removeprefix("sha256:")
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise ReleaseCloseoutError("artifact digest must be a SHA256 hash")
+    if re.fullmatch(r"[0-9a-f]{40}", release_commit) is None:
+        raise ReleaseCloseoutError("release commit must be a full commit SHA")
+    if not expected_version:
+        raise ReleaseCloseoutError("expected version must not be empty")
+    data = archive.read_bytes()
+    if hashlib.sha256(data).hexdigest() != digest:
+        raise ReleaseCloseoutError("archive digest does not match the publisher output")
+    files: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(data)) as source:
+        for member in source.infolist():
+            name = member.filename
+            kind = stat.S_IFMT(member.external_attr >> 16)
+            if (
+                re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_.+-]*", name) is None
+                or name != member.orig_filename
+                or name in files
+                or member.is_dir()
+                or kind not in (0, stat.S_IFREG)
+            ):
+                raise ReleaseCloseoutError(f"archive contains an unsafe or duplicate member: {name!r}")
+            files[name] = source.read(member)
+    metadata = {"release-inventory.json", "qualification-provenance.json"}
+    if not metadata <= files.keys():
+        raise ReleaseCloseoutError("archive is missing release metadata")
+    inventory = _object(files["release-inventory.json"], "release inventory")
+    provenance = _object(files["qualification-provenance.json"], "qualification provenance")
+    if inventory.get("version") != expected_version:
+        raise ReleaseCloseoutError("inventory version does not match the requested release")
+    if provenance.get("head_sha") != release_commit:
+        raise ReleaseCloseoutError("qualification commit does not match the requested release")
+    artifacts = inventory.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ReleaseCloseoutError("inventory must contain a nonempty artifacts list")
+    expected: set[str] = set()
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ReleaseCloseoutError("inventory artifact must be an object")
+        artifact_name = artifact.get("name")
+        size = artifact.get("bytes")
+        checksum = artifact.get("sha256")
+        if (
+            not isinstance(artifact_name, str)
+            or not artifact_name.endswith((".whl", ".tar.gz", ".vsix"))
+            or artifact_name in expected
+            or artifact_name not in files
+            or type(size) is not int
+            or size < 0
+            or not isinstance(checksum, str)
+            or re.fullmatch(r"[0-9a-f]{64}", checksum) is None
+        ):
+            raise ReleaseCloseoutError("inventory contains an invalid or duplicate artifact")
+        payload = files[artifact_name]
+        if len(payload) != size or hashlib.sha256(payload).hexdigest() != checksum:
+            raise ReleaseCloseoutError(f"artifact bytes do not match the inventory: {artifact_name}")
+        expected.add(artifact_name)
+    if any(name.endswith(".vsix") for name in expected) and "registry-verification.json" not in files:
+        raise ReleaseCloseoutError("VSIX releases require registry verification")
+    if "registry-verification.json" in files:
+        if not all(name.endswith(".vsix") for name in expected):
+            raise ReleaseCloseoutError("registry verification is only supported for VSIX releases")
+        _object(files["registry-verification.json"], "registry verification")
+        metadata.add("registry-verification.json")
+    if files.keys() != expected | metadata:
+        raise ReleaseCloseoutError("archive contains files outside the release inventory")
+    if output_dir.is_symlink() or (output_dir.exists() and (not output_dir.is_dir() or any(output_dir.iterdir()))):
+        raise ReleaseCloseoutError("output directory must be new or empty")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, payload in files.items():
+        with (output_dir / name).open("xb") as destination:
+            destination.write(payload)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate the archive supplied by the publisher job."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--artifact-digest", required=True)
+    parser.add_argument("--release-commit", required=True)
+    parser.add_argument("--version", dest="expected_version", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        extract_closeout(**vars(args))
+    except (OSError, ValueError, zipfile.BadZipFile, RuntimeError) as error:
+        sys.stderr.write(f"Release closeout error: {error}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_tag.py
+++ b/scripts/release_tag.py
@@ -1,0 +1,150 @@
+"""Create an immutable package tag after its publication job succeeds."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from scripts.release import FULL_SHA, PACKAGE_BY_KEY, tomllib
+
+
+class ReleaseTagError(RuntimeError):
+    """The package tag cannot be created safely."""
+
+
+def _git(repo: Path, *args: str, authenticated: bool = False) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if authenticated:
+        token = env.get("RELEASE_APP_TOKEN", "")
+        if not token:
+            raise ReleaseTagError("RELEASE_APP_TOKEN is missing")
+        # Keep the credential out of command arguments and repository configuration.
+        authorization = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        env.update(
+            GIT_CONFIG_COUNT="1",
+            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader",
+            GIT_CONFIG_VALUE_0=f"AUTHORIZATION: basic {authorization}",
+        )
+    return subprocess.run(
+        [shutil.which("git") or "/usr/bin/git", *args],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _required(repo: Path, *args: str) -> str:
+    result = _git(repo, *args)
+    if result.returncode:
+        raise ReleaseTagError(f"git {args[0]} failed")
+    return result.stdout.strip()
+
+
+def _validate_tag_object(repo: Path, ref: str, tag: str, commit: str) -> None:
+    if _required(repo, "cat-file", "-t", ref) != "tag":
+        raise ReleaseTagError("The existing release tag is not annotated")
+    if _required(repo, "rev-parse", f"{ref}^{{commit}}") != commit:
+        raise ReleaseTagError("The existing release tag names a different commit")
+    # Ref aliases and nested tags must not disguise a different release identity.
+    headers = _required(repo, "cat-file", "-p", ref).split("\n\n", maxsplit=1)[0].splitlines()
+    if headers[:3] != [f"object {commit}", "type commit", f"tag {tag}"]:
+        raise ReleaseTagError("The annotated tag has a different internal identity")
+
+
+def _remote_tag(repo: Path, tag: str, commit: str) -> bool:
+    result = _git(repo, "ls-remote", "--exit-code", "--tags", "origin", f"refs/tags/{tag}")
+    if result.returncode == 2:
+        return False
+    if result.returncode:
+        raise ReleaseTagError("Could not query the remote tag")
+    # Fetch the exact remote object, independent of any existing local tag.
+    _required(repo, "fetch", "--no-tags", "origin", f"refs/tags/{tag}")
+    _validate_tag_object(repo, "FETCH_HEAD", tag, commit)
+    return True
+
+
+def validate(repo: Path, package: str, commit: str, tag: str) -> bool:
+    """Validate the release identity and return whether its remote tag exists."""
+    if FULL_SHA.fullmatch(commit) is None:
+        raise ReleaseTagError("The release commit must be a full lowercase Git SHA")
+    spec = PACKAGE_BY_KEY.get(package)
+    if spec is None:
+        raise ReleaseTagError("Unknown release package")
+    # Historical source is data; privileged jobs execute only trusted main code.
+    _required(repo, "fetch", "--no-tags", "origin", "main:refs/remotes/origin/main")
+    if _required(repo, "cat-file", "-t", commit) != "commit":
+        raise ReleaseTagError("The release SHA must name a commit object")
+    _required(repo, "merge-base", "--is-ancestor", commit, "refs/remotes/origin/main")
+    raw = _required(repo, "show", f"{commit}:{spec.manifest}")
+    try:
+        manifest = json.loads(raw) if spec.manifest_kind == "json" else tomllib.loads(raw)
+        project = manifest if spec.manifest_kind == "json" else manifest["project"]
+        version = project["version"]
+    except (ValueError, KeyError, TypeError) as error:
+        raise ReleaseTagError("The release manifest has no valid version") from error
+    if (
+        not isinstance(version, str)
+        or re.fullmatch(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:[a-zA-Z0-9.+-]*)?", version) is None
+    ):
+        raise ReleaseTagError("The release manifest version is invalid")
+    if tag != f"{spec.tag_prefix}{version}":
+        raise ReleaseTagError("The requested tag does not match the source package version")
+    _required(repo, "check-ref-format", f"refs/tags/{tag}")
+    return _remote_tag(repo, tag, commit)
+
+
+def create(repo: Path, package: str, commit: str, tag: str) -> None:
+    """Create the validated annotated tag, accepting an identical concurrent creation."""
+    if validate(repo, package, commit, tag):
+        return
+    local = _git(repo, "rev-parse", "--verify", f"refs/tags/{tag}")
+    if local.returncode == 0:
+        _validate_tag_object(repo, f"refs/tags/{tag}", tag, commit)
+    else:
+        _required(
+            repo,
+            "-c",
+            "user.name=citry-release[bot]",
+            "-c",
+            "user.email=citry-release[bot]@users.noreply.github.com",
+            "tag",
+            "-a",
+            tag,
+            commit,
+            "-m",
+            f"Release {tag}",
+        )
+    pushed = _git(repo, "push", "origin", f"refs/tags/{tag}:refs/tags/{tag}", authenticated=True)
+    # A concurrent successful publisher is safe only when its tag also agrees.
+    exists = _remote_tag(repo, tag, commit)
+    if pushed.returncode and not exists:
+        raise ReleaseTagError("The release tag push failed")
+    if not exists:
+        raise ReleaseTagError("The pushed release tag is missing")
+
+
+def main() -> None:
+    """Validate or create the package tag requested by the trusted workflow."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("validate", "create"))
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--release-commit", required=True)
+    parser.add_argument("--release-tag", required=True)
+    args = parser.parse_args()
+    try:
+        operation = create if args.operation == "create" else validate
+        operation(Path.cwd(), args.package, args.release_commit, args.release_tag)
+    except ReleaseTagError as error:
+        parser.exit(1, f"Release tag rejected: {error}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,7 +7,8 @@ descriptions, empty when the invariant holds. Validators are discovered
 automatically, so adding one is just dropping a new `<name>.py` file in that
 directory (files whose name starts with `_` are skipped).
 
-Run directly, or as the `validators` phase of scripts/check.py.
+Run with `uv run --no-sync python scripts/validate.py`, or as the
+`validators` phase of scripts/check.py, to use the workspace dependencies.
 """
 
 import importlib.util

--- a/scripts/validators/release_security.py
+++ b/scripts/validators/release_security.py
@@ -1,0 +1,86 @@
+"""Keep package publication and release App credentials in separate jobs."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGES = ("citry-core", "citry", "citry-lsp", "citry-ui", "pygments-citry", "vscode-citry")
+TAG_WORKFLOW = "repo--release-tag.yml"
+APP_JOBS = {(TAG_WORKFLOW, "tag"), ("repo--docs-release.yml", "commit")}
+
+
+def check(root: Path = ROOT) -> list[str]:
+    """Check the reviewed workflow structure; GitHub environment rules enforce refs."""
+    errors: list[str] = []
+    directory = root / ".github/workflows"
+    workflows: dict[str, Any] = {}
+    for path in directory.glob("*.yml"):
+        workflows[path.name] = yaml.safe_load(path.read_text())
+    publishers = {
+        ("vscode--citry--publish.yml" if package == "vscode-citry" else f"py--{package}--publish.yml"): package
+        for package in PACKAGES
+    }
+    for filename, workflow in workflows.items():
+        for name, job in workflow.get("jobs", {}).items():
+            environment = job.get("environment")
+            if isinstance(environment, dict):
+                environment = environment.get("name")
+            if job.get("uses") == f"./.github/workflows/{TAG_WORKFLOW}" and (
+                filename not in publishers or name != "tag"
+            ):
+                errors.append(f"{filename}:{name} calls protected tag creation outside the package publishers")
+            if environment in ("pypi", "vscode-marketplaces") and (filename not in publishers or name != "release"):
+                errors.append(f"{filename}:{name} has a publishing environment outside its publication job")
+            if environment == "release-maintenance" and (filename, name) not in APP_JOBS:
+                errors.append(f"{filename}:{name} has unexpected release App access")
+            if "RELEASE_APP_PRIVATE_KEY" in str(job) and (filename, name) not in APP_JOBS:
+                errors.append(f"{filename}:{name} uses the release key outside its isolated write job")
+    for filename, package in publishers.items():
+        jobs = workflows.get(filename, {}).get("jobs", {})
+        release, tag, closeout = (jobs.get(name, {}) for name in ("release", "tag", "closeout"))
+        expected_environment = "vscode-marketplaces" if package == "vscode-citry" else "pypi"
+        if release.get("environment") != expected_environment:
+            errors.append(f"{filename} publication must use {expected_environment}")
+        if release.get("permissions", {}).get("contents") != "read":
+            errors.append(f"{filename} publication must not write repository contents")
+        if tag.get("uses") != f"./.github/workflows/{TAG_WORKFLOW}" or "release" not in tag.get("needs", []):
+            errors.append(f"{filename} must create its tag only after verified publication")
+        if tag.get("if") or tag.get("secrets"):
+            errors.append(f"{filename} tag creation must use successful dependencies and its own environment secrets")
+        if (
+            tag.get("with", {}).get("release_commit") != "${{ inputs.release_commit }}"
+            or tag.get("with", {}).get("release_tag") != package + "@${{ needs.verify-version.outputs.version }}"
+        ):
+            errors.append(f"{filename} tag creation must use the published source identity")
+        if tag.get("with", {}).get("package") != package:
+            errors.append(f"{filename} must pass its fixed package identity to tag creation")
+        if not {"release", "tag"}.issubset(closeout.get("needs", [])) or closeout.get("environment"):
+            errors.append(
+                f"{filename} closeout must follow publication and tag creation without publishing credentials"
+            )
+        checkouts = [
+            step for step in closeout.get("steps", []) if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        if len(checkouts) != 1 or checkouts[0].get("with", {}).get("ref") != "${{ github.sha }}":
+            errors.append(f"{filename} closeout must execute trusted workflow source")
+        if "scripts.release_closeout" not in str(closeout) or "needs.release.outputs.closeout_digest" not in str(
+            closeout
+        ):
+            errors.append(f"{filename} closeout must verify the transferred artifact digest")
+        if str(closeout).count("scripts.verify_github_release") != 2 or "--require-existing" not in str(closeout):
+            errors.append(f"{filename} must verify existing and newly created GitHub Release assets")
+    workflow = workflows.get(TAG_WORKFLOW, {})
+    events = workflow.get("on", workflow.get(True, {}))
+    if not isinstance(events, dict) or set(events) != {"workflow_call"}:
+        errors.append("Protected tag creation must expose only workflow_call")
+    job = workflow.get("jobs", {}).get("tag", {})
+    if job.get("environment") != "release-maintenance" or job.get("if") != "github.ref == 'refs/heads/main'":
+        errors.append("Protected tag creation must use the main-only release environment")
+    checkouts = [step for step in job.get("steps", []) if str(step.get("uses", "")).startswith("actions/checkout@")]
+    if len(checkouts) != 1 or checkouts[0].get("with", {}).get("ref") != "${{ github.sha }}":
+        errors.append("Protected tag creation must execute trusted workflow source")
+    if "scripts.release_tag validate" not in str(job) or "scripts.release_tag create" not in str(job):
+        errors.append("Protected tag creation must validate the immutable package identity")
+    return errors

--- a/scripts/verify_github_release.py
+++ b/scripts/verify_github_release.py
@@ -1,0 +1,241 @@
+"""Check existing GitHub Releases against files verified by the publication job without changing them."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+class GitHubReleaseError(ValueError):
+    """A release is absent, incomplete, or different from the verified files."""
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, _req: Any, _fp: Any, _code: int, _msg: str, _headers: Any, _newurl: str) -> None:
+        """Keep the GitHub token on the exact API endpoint requested."""
+        return
+
+
+def fetch_release(*, repository: str, tag: str, token: str) -> tuple[int, dict[str, Any] | None]:
+    """Read one release from GitHub's API, refusing every redirect."""
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository) is None:
+        raise GitHubReleaseError("repository must be an owner/repository name")
+    if not tag or tag in (".", "..") or any(ord(char) < 32 for char in tag):
+        raise GitHubReleaseError("release tag must not be empty or contain control characters")
+    if not token:
+        raise GitHubReleaseError("GH_TOKEN must be set")
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/releases/tags/{urllib.parse.quote(tag, safe='')}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.build_opener(_NoRedirect()).open(request, timeout=60) as response:
+            status = response.status
+            if status != 200:
+                raise GitHubReleaseError(f"GitHub release lookup returned HTTP {status}")
+            payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return 404, None
+        raise GitHubReleaseError(f"GitHub release lookup returned HTTP {error.code}") from error
+    except (urllib.error.URLError, OSError) as error:
+        raise GitHubReleaseError("GitHub release lookup failed") from error
+    if not isinstance(payload, dict):
+        raise GitHubReleaseError("GitHub release response must contain an object")
+    return status, payload
+
+
+class _HTTPSRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str
+    ) -> urllib.request.Request | None:
+        """Allow public asset downloads to follow only HTTPS redirects."""
+        if urllib.parse.urlsplit(newurl).scheme != "https":
+            raise GitHubReleaseError("public release metadata redirected outside HTTPS")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _public_bytes(url: str) -> bytes:
+    """Download public bytes without attaching any GitHub credentials."""
+    try:
+        with urllib.request.build_opener(_HTTPSRedirect()).open(url, timeout=60) as response:
+            if response.status != 200:
+                raise GitHubReleaseError(f"public release metadata returned HTTP {response.status}")
+            return response.read()
+    except (urllib.error.URLError, OSError) as error:
+        raise GitHubReleaseError("could not download public release metadata") from error
+
+
+def _verify_attestation(*, repository: str, tag: str, name: str, parent_digest: str, size: int, digest: str) -> None:
+    """Accept a publish attestation only when PyPI records the same object for these bytes."""
+    package, separator, version = tag.partition("@")
+    if (
+        not separator
+        or package not in {"citry", "citry-core", "citry-lsp", "citry-ui", "pygments-citry"}
+        or re.fullmatch(r"[0-9][A-Za-z0-9.+!-]*", version) is None
+        or re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository) is None
+    ):
+        raise GitHubReleaseError("publish attestations require a known PyPI package release")
+    parent = name.removesuffix(".publish.attestation")
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    encoded_name = urllib.parse.quote(name, safe="")
+    data = _public_bytes(f"https://github.com/{repository}/releases/download/{encoded_tag}/{encoded_name}")
+    if len(data) != size or "sha256:" + hashlib.sha256(data).hexdigest() != digest:
+        raise GitHubReleaseError("publish attestation bytes differ from GitHub asset metadata")
+    attestation = json.loads(data)
+    encoded_parent = urllib.parse.quote(parent, safe="")
+    provenance = json.loads(
+        _public_bytes(f"https://pypi.org/integrity/{package}/{version}/{encoded_parent}/provenance")
+    )
+    bundles = provenance.get("attestation_bundles") if isinstance(provenance, dict) else None
+    if not isinstance(attestation, dict) or not isinstance(bundles, list):
+        raise GitHubReleaseError("PyPI publish attestation metadata is invalid")
+    encoded_attestation = json.dumps(attestation, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    if not any(
+        isinstance(bundle, dict)
+        and isinstance(bundle.get("attestations"), list)
+        and any(
+            json.dumps(item, sort_keys=True, separators=(",", ":"), allow_nan=False) == encoded_attestation
+            for item in bundle["attestations"]
+        )
+        and isinstance(bundle.get("publisher"), dict)
+        and bundle["publisher"].get("repository") == repository
+        for bundle in bundles
+    ):
+        raise GitHubReleaseError("publish attestation does not match PyPI provenance")
+    envelope = attestation.get("envelope")
+    encoded_statement = envelope.get("statement") if isinstance(envelope, dict) else None
+    if not isinstance(encoded_statement, str):
+        raise GitHubReleaseError("publish attestation has no statement")
+    statement = json.loads(base64.b64decode(encoded_statement, validate=True))
+    if (
+        not isinstance(statement, dict)
+        or statement.get("subject") != [{"name": parent, "digest": {"sha256": parent_digest.removeprefix("sha256:")}}]
+        or statement.get("predicateType") != "https://docs.pypi.org/attestations/publish/v1"
+    ):
+        raise GitHubReleaseError("publish attestation does not identify the approved package bytes")
+
+
+def verify_release(
+    *,
+    status: int,
+    payload: Mapping[str, Any] | None,
+    tag: str,
+    assets_dir: Path,
+    repository: str = "",
+    require_existing: bool = False,
+) -> bool:
+    """
+    Accept a missing release or one whose complete asset set matches local files.
+
+    Extra PyPI publish attestations are accepted only when they match PyPI
+    provenance and identify the verified package bytes. Draft, partial, or
+    different releases require manual reconciliation. This check never edits
+    an existing release or replaces its assets.
+    """
+    if status == 404 and payload is None:
+        if require_existing:
+            raise GitHubReleaseError("the required GitHub Release does not exist")
+        return False
+    if status != 200 or payload is None:
+        raise GitHubReleaseError(f"could not verify the GitHub Release; HTTP {status}")
+    if payload.get("draft") is not False or payload.get("tag_name") != tag:
+        raise GitHubReleaseError("existing release is a draft or has a different tag; reconcile it manually")
+    if assets_dir.is_symlink() or not assets_dir.is_dir():
+        raise GitHubReleaseError("verified assets directory must be a directory")
+    expected: dict[str, tuple[int, str]] = {}
+    for path in assets_dir.iterdir():
+        if path.is_symlink() or not path.is_file():
+            raise GitHubReleaseError("verified assets directory must contain only regular files")
+        data = path.read_bytes()
+        expected[path.name] = (len(data), "sha256:" + hashlib.sha256(data).hexdigest())
+    if not expected:
+        raise GitHubReleaseError("verified assets directory must not be empty")
+    assets = payload.get("assets")
+    if not isinstance(assets, list):
+        raise GitHubReleaseError("existing release has no assets list; reconcile it manually")
+    actual: dict[str, tuple[int, str]] = {}
+    for asset in assets:
+        if not isinstance(asset, dict):
+            raise GitHubReleaseError("existing release contains an invalid asset")
+        name = asset.get("name")
+        size = asset.get("size")
+        digest = asset.get("digest")
+        if (
+            not isinstance(name, str)
+            or name in actual
+            or type(size) is not int
+            or size < 0
+            or not isinstance(digest, str)
+            or re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is None
+            or asset.get("state") != "uploaded"
+        ):
+            raise GitHubReleaseError("existing release has unverified or duplicate assets; reconcile it manually")
+        actual[name] = (size, digest)
+    for name in actual.keys() - expected.keys():
+        parent = name.removesuffix(".publish.attestation")
+        if (
+            not name.endswith(".publish.attestation")
+            or parent not in expected
+            or not parent.endswith((".whl", ".tar.gz"))
+        ):
+            raise GitHubReleaseError("existing release has unrelated extra assets; reconcile it manually")
+        size, digest = actual[name]
+        _verify_attestation(
+            repository=repository, tag=tag, name=name, parent_digest=expected[parent][1], size=size, digest=digest
+        )
+    actual = {name: identity for name, identity in actual.items() if name in expected}
+    if actual != expected:
+        raise GitHubReleaseError("existing release assets differ from the verified files; reconcile it manually")
+    return True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Check whether publication can create a release or reuse its exact assets."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--assets-dir", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--require-existing", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        status, payload = fetch_release(repository=args.repository, tag=args.tag, token=os.environ.get("GH_TOKEN", ""))
+        exists = verify_release(
+            status=status,
+            payload=payload,
+            tag=args.tag,
+            repository=args.repository,
+            assets_dir=args.assets_dir,
+            require_existing=args.require_existing,
+        )
+        result = f"release_exists={'true' if exists else 'false'}\n"
+        if args.github_output is not None:
+            with args.github_output.open("a", encoding="utf-8") as output:
+                output.write(result)
+    except (GitHubReleaseError, OSError, ValueError) as error:
+        sys.stderr.write(f"GitHub Release verification error: {error}\n")
+        return 1
+    sys.stdout.write(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -428,6 +428,7 @@ social-cards = [
 dev = [
     { name = "maturin" },
     { name = "mypy" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -454,6 +455,7 @@ provides-extras = ["docs", "social-cards"]
 dev = [
     { name = "maturin", specifier = ">=1.10.2" },
     { name = "mypy", specifier = ">=1.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.10.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
 ]


### PR DESCRIPTION
Package publication could succeed and then stop because the default Actions token could not create a protected release tag. Separate publication, tag creation and GitHub Release creation so the dedicated release App creates only the verified annotated tag, while ordinary jobs handle the published files and release assets.

The tag helper checks the package version at the qualified commit, its ancestry on main, and existing annotated tag identity. Release assets cross jobs in a digest-checked artifact, and retries reject draft, incomplete or mismatched GitHub Releases. Existing PyPI publication attestations are accepted only after checking their GitHub hashes, PyPI provenance and artifact identity.

Publishing environments now permit only main. A repository validator guards workflow dependencies and credential placement. Independent human approvals are deferred to #112 until the maintainer team grows.

Validation: targeted regression tests, live verification against all five current package Releases, Ruff, mypy and repository validators. A harmless branch probe confirmed that all three release environments rejected jobs from the probe branch before any step runs.

CI note: Lighthouse repeats the existing homepage best-practices failure (0.96 against 1.00), also seen before this change. This PR does not change the homepage.

Continues #46.
