### PR TITLE
Send VS Code release notices to development

### DIFF
--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -1365,11 +1365,13 @@ that consume versioned protocols must still validate those schemas.
 Development updates to `main` require a pull request, the `check` job, an
 up-to-date branch, and resolved review conversations. Zero approving reviews
 are required while the repository has one maintainer, so that maintainer can
-merge their own PR after checks pass. This provides a PR history, not
-independent approval against compromise of that maintainer's account.
+merge their own PR after checks pass. `JuroOravec` also has a **For pull requests
+only** bypass to merge selected PRs without waiting for checks. This does not
+permit direct pushes to `main`. The PR history remains, but the sole-maintainer
+process does not provide independent approval.
 
-Generated release site updates use a dedicated GitHub App as the only bypass
-actor for the PR and status-check rules. A separate ruleset blocks deletion and
+Generated release site updates use a dedicated GitHub App as the only always-allowed
+bypass actor for the PR and status-check rules. A separate ruleset blocks deletion and
 force pushes without bypass actors. GitHub's App bypass applies to the branch;
 the trusted workflow enforces the file restriction. The write job accepts only
 `docs_site/versions/` and `docs_site/static/playground/runtime.json`, after the
@@ -1389,8 +1391,8 @@ Configure the release identity once before enabling this workflow:
    private key out of repository-wide, organization-wide, and Dependabot secrets.
 3. Add this App alone as an always-allowed bypass actor for the exact-main PR
    and status-check ruleset. Keep deletion and force-push protection in a
-   separate ruleset with no bypass. Ordinary users and `github-actions` receive
-   no bypass.
+   separate ruleset with no bypass. Give `JuroOravec` only the pull-request bypass
+   described above. Other users and `github-actions` receive no bypass.
 
 The build job has only the read token and no release environment. A fresh write
 job accesses `release-maintenance`, mints a short-lived repository-scoped App

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -1366,8 +1366,9 @@ Development updates to `main` require a pull request, the `check` job, an
 up-to-date branch, and resolved review conversations. Zero approving reviews
 are required while the repository has one maintainer, so that maintainer can
 merge their own PR after checks pass. `JuroOravec` also has a **For pull requests
-only** bypass to merge selected PRs without waiting for checks. This does not
-permit direct pushes to `main`. The PR history remains, but the sole-maintainer
+only** bypass on the separate required-check ruleset to merge selected PRs
+without waiting for checks. The PR and resolved-conversation requirements still
+apply, and direct pushes to `main` remain blocked. The PR history remains, but the sole-maintainer
 process does not provide independent approval.
 
 Generated release site updates use a dedicated GitHub App as the only always-allowed
@@ -1390,9 +1391,9 @@ Configure the release identity once before enabling this workflow:
    `main`, with no tag rules. Keep the
    private key out of repository-wide, organization-wide, and Dependabot secrets.
 3. Add this App alone as an always-allowed bypass actor for the exact-main PR
-   and status-check ruleset. Keep deletion and force-push protection in a
-   separate ruleset with no bypass. Give `JuroOravec` only the pull-request bypass
-   described above. Other users and `github-actions` receive no bypass.
+   and status-check rulesets. Keep deletion and force-push protection in a
+   separate ruleset with no bypass. Give `JuroOravec` the pull-request-only bypass
+   on the required-check ruleset alone. Other users and `github-actions` receive no bypass.
 
 The build job has only the read token and no release environment. A fresh write
 job accesses `release-maintenance`, mints a short-lived repository-scoped App

--- a/packages/py/citry/tests/test_discord_release.py
+++ b/packages/py/citry/tests/test_discord_release.py
@@ -25,7 +25,7 @@ from scripts.discord_release import (  # noqa: E402
     [
         ("citry@0.4.5", "announcements"),
         ("citry-ui@0.3.0", "announcements"),
-        ("vscode-citry@0.1.2", "announcements"),
+        ("vscode-citry@0.1.2", "development"),
         ("citry-lsp@0.1.3", "development"),
         ("citry-core@1.7.0", "development"),
         ("pygments-citry@0.2.1", "development"),

--- a/scripts/discord_release.py
+++ b/scripts/discord_release.py
@@ -31,7 +31,7 @@ class ReleaseRoute:
 RELEASE_ROUTES = (
     ReleaseRoute("citry@", "announcements", "py--citry--publish.yml"),
     ReleaseRoute("citry-ui@", "announcements", "py--citry-ui--publish.yml"),
-    ReleaseRoute("vscode-citry@", "announcements", "vscode--citry--publish.yml"),
+    ReleaseRoute("vscode-citry@", "development", "vscode--citry--publish.yml"),
     ReleaseRoute("citry-lsp@", "development", "py--citry-lsp--publish.yml"),
     ReleaseRoute("citry-core@", "development", "py--citry-core--publish.yml"),
     ReleaseRoute("pygments-citry@", "development", "py--pygments-citry--publish.yml"),


### PR DESCRIPTION
Send vscode-citry release notifications to development, leaving only Citry and Citry UI in announcements.

Document the maintainer's explicitly requested PR-only check bypass. Direct pushes, force pushes and tag changes retain their separate restrictions.

Validation: all 14 existing Discord release tests pass; independent review found no blockers.
