### PR TITLE
Run Citry template checks in starter and demo CI

### DIFF
--- a/docs/design/example_projects.md
+++ b/docs/design/example_projects.md
@@ -199,6 +199,7 @@ Each entry records at least:
 | `path` | Repository-relative project root below `examples/`. |
 | `host` | `none`, `fastapi`, `django`, `flask`, `asgi`, or `wsgi` initially. |
 | `python` | Supported Python constraint for the project. |
+| `check` | Required shell-free argument vector for registry-aware Citry template checks. |
 | `test` | Shell-free argument vector for the project-local test command. |
 | `serve` | Shell-free argument vector with a `{port}` placeholder; absent for standalone. |
 | `page_path` | HTTP path whose response is the complete page. |
@@ -408,6 +409,7 @@ Every project contains:
 README.md
 pyproject.toml
 uv.lock
+.github/workflows/check.yml
 .env.example        # web projects only
 src/ or host-native application files
 tests/
@@ -699,6 +701,23 @@ owns a stable visual contract. It is not a substitute for semantic browser
 assertions.
 
 ### 8.6 CI placement
+
+Every project includes `.github/workflows/check.yml` for readers who copy the
+project, including hidden directories, to their own repository root. It runs
+on pushes and pull requests with read-only repository permissions, installs
+locked dependencies, checks templates through the project's Citry app, then
+runs pytest. The workflow supplies fixed test-only secrets where the app needs
+them; Django also receives `DJANGO_SETTINGS_MODULE=config.settings`. Project
+READMEs show the same local check command and any required environment setup.
+
+GitHub does not run these nested workflows inside the Citry monorepo. The
+shared qualifier runs each cataloged `check` command before its `test` command
+in the clean project copy. A failing check stops qualification before tests or
+browser startup. Django settings are scoped to that project's environment.
+Catalog loading rejects a missing or malformed `check` command, and clean-copy
+validation rejects a missing project workflow. Archive tests verify that the
+workflow travels with the copied project.
+
 
 Example qualification should have a dedicated Python workflow or dedicated
 jobs with path filters that include:

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -13,7 +13,7 @@ These rules apply to every complete project under `examples/`.
   standalone starter deliberately has no Events transport.
 - Keep data deterministic and make the default run independent of external
   services, CDNs, and network APIs.
-- Run the project-local tests and the applicable shared qualification profile
+- Run the README Citry template check, the project-local tests and the applicable shared qualification profile
   after a change.
 - Update `examples/catalog.toml`, the project README, dependency lock, and
   discovery links when their claims change.

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,7 +54,10 @@ private data or write operations.
 ## How these projects are maintained
 
 Each project has its own `pyproject.toml`, lock file, README, application code,
-and tests. CI copies each project to a temporary directory and runs its tests.
+and tests. Each also includes a GitHub Actions workflow that checks Citry
+templates and runs pytest after you copy the project to your own repository.
+Its README shows the same local commands. Citry's monorepo CI copies each
+project to a temporary directory and runs its template checks and tests.
 For web projects, it starts the server and clicks through the interactions in
 a real browser. For the standalone starter, it opens the generated HTML file.
 The web starters cover Alpine and Citry Events; the standalone starter covers

--- a/examples/_internal/catalog.py
+++ b/examples/_internal/catalog.py
@@ -22,6 +22,7 @@ class ExampleProject:
     path: Path
     host: str
     python: str
+    check: tuple[str, ...]
     test: tuple[str, ...]
     profile: str
     docs: tuple[str, ...]
@@ -64,6 +65,9 @@ def load_catalog(path: Path = CATALOG_PATH) -> tuple[ExampleProject, ...]:
         relative = Path(raw["path"])
         if relative.is_absolute() or ".." in relative.parts:
             raise ValueError(f"{project_id}: path must stay under examples/")
+        check = _command(raw.get("check"), "check", project_id)
+        if check is None:
+            raise ValueError(f"{project_id}: check command is required")
         projects.append(
             ExampleProject(
                 id=project_id,
@@ -71,6 +75,7 @@ def load_catalog(path: Path = CATALOG_PATH) -> tuple[ExampleProject, ...]:
                 path=relative,
                 host=raw["host"],
                 python=raw["python"],
+                check=check,
                 test=_command(raw.get("test"), "test", project_id) or (),
                 build=_command(raw.get("build"), "build", project_id),
                 serve=_command(raw.get("serve"), "serve", project_id),

--- a/examples/_internal/qualify.py
+++ b/examples/_internal/qualify.py
@@ -86,7 +86,7 @@ def project_environment() -> dict[str, str]:
 def copy_project(project: ExampleProject, root: Path) -> Path:
     destination = root / project.id
     shutil.copytree(project.source, destination, ignore=COPY_IGNORES)
-    for required in ("README.md", "pyproject.toml", "uv.lock", "tests"):
+    for required in ("README.md", "pyproject.toml", "uv.lock", "tests", ".github/workflows/check.yml"):
         if not (destination / required).exists():
             raise RuntimeError(f"{project.id}: copied project is missing {required}")
     return destination
@@ -814,6 +814,10 @@ def qualify_project(
     browser: str | None,
     timeout: float,
 ) -> None:
+    environment = environment.copy()
+    if project.host == "django":
+        environment["DJANGO_SETTINGS_MODULE"] = "config.settings"
+    run_checked(project.check, project_dir, environment)
     run_checked(project.test, project_dir, environment)
     if project.build is not None:
         run_checked(project.build, project_dir, environment)

--- a/examples/catalog.toml
+++ b/examples/catalog.toml
@@ -4,6 +4,7 @@ schema = 1
 id = "starter-standalone"
 kind = "starter"
 path = "starters/standalone"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "none"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -15,6 +16,7 @@ docs = ["/getting-started/installation/", "/syntax/alpine/"]
 id = "starter-fastapi"
 kind = "starter"
 path = "starters/fastapi"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "fastapi"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -28,6 +30,7 @@ docs = ["/getting-started/fastapi/", "/web-frameworks/#fastapi-and-starlette"]
 id = "starter-django"
 kind = "starter"
 path = "starters/django"
+check = ["uv", "run", "citry", "--app", "project_explorer.citry_app:citry_app", "check"]
 host = "django"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -41,6 +44,7 @@ docs = ["/web-frameworks/#django", "/security/#protect-event-posts-from-csrf"]
 id = "starter-flask"
 kind = "starter"
 path = "starters/flask"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "flask"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -54,6 +58,7 @@ docs = ["/web-frameworks/#flask", "/events/"]
 id = "starter-asgi"
 kind = "starter"
 path = "starters/asgi"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "asgi"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -67,6 +72,7 @@ docs = ["/web-frameworks/#bare-asgi-and-wsgi", "/events/"]
 id = "starter-wsgi"
 kind = "starter"
 path = "starters/wsgi"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "wsgi"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -80,6 +86,7 @@ docs = ["/web-frameworks/#bare-asgi-and-wsgi", "/events/"]
 id = "demo-project-board"
 kind = "demo"
 path = "demos/project_board"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "fastapi"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]
@@ -93,6 +100,7 @@ docs = ["/examples/", "/events/"]
 id = "demo-htmx"
 kind = "demo"
 path = "demos/htmx"
+check = ["uv", "run", "citry", "--app", "app.citry_app:citry_app", "check"]
 host = "fastapi"
 python = ">=3.10,<4"
 test = ["uv", "run", "pytest"]

--- a/examples/demos/htmx/.github/workflows/check.yml
+++ b/examples/demos/htmx/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/demos/htmx/README.md
+++ b/examples/demos/htmx/README.md
@@ -42,9 +42,17 @@ The locked project uses Citry 0.4.6.
 
 ## Test it
 
+Check component templates with the app registry, then run the tests:
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 Citry's repository checks also copy the project to a temporary directory,
 start the server, and run all three interactions in a real browser.

--- a/examples/demos/project_board/.github/workflows/check.yml
+++ b/examples/demos/project_board/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CITRY_SECRET: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/demos/project_board/README.md
+++ b/examples/demos/project_board/README.md
@@ -67,9 +67,19 @@ editor discovery worker.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/starters/asgi/.github/workflows/check.yml
+++ b/examples/starters/asgi/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CITRY_SECRET: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/asgi/AGENTS.md
+++ b/examples/starters/asgi/AGENTS.md
@@ -17,7 +17,9 @@
   The app reads the environment directly; `.env.example` records its setup.
 - Treat `State` as browser input. Keep secrets on the server and check
   authorization before returning private data or performing writes.
-- After changes, run `uv run pytest`; the local checks live in `tests/test_app.py`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app app.citry_app:citry_app check`, then run `uv run pytest`.
+  The local tests live in `tests/test_app.py`.
 - For template, CSS, Events, or host changes, run the README server command
   and check the page in a browser. Verify the help button, search results,
   input focus, and browser console and network errors.

--- a/examples/starters/asgi/README.md
+++ b/examples/starters/asgi/README.md
@@ -63,9 +63,19 @@ This README remains the source for installation, secret setup, and run commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/starters/django/.github/workflows/check.yml
+++ b/examples/starters/django/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: config.settings
+      DJANGO_SECRET_KEY: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app project_explorer.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/django/AGENTS.md
+++ b/examples/starters/django/AGENTS.md
@@ -18,7 +18,9 @@
   The app reads the environment directly; `.env.example` records its setup.
 - Treat `State` as browser input. Keep secrets on the server and check
   authorization before returning private data or performing writes.
-- After changes, run `uv run pytest`; the local checks live in `tests/test_app.py`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app project_explorer.citry_app:citry_app check`, then run `uv run pytest`.
+  The local tests live in `tests/test_app.py`.
 - For template, CSS, Events, or host changes, run the README server command
   and check the page in a browser. Verify the help button, search results,
   input focus, and browser console and network errors.

--- a/examples/starters/django/README.md
+++ b/examples/starters/django/README.md
@@ -64,9 +64,30 @@ This README remains the source for installation, secret setup, and run commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
+On macOS or Linux:
+
 ```console
+export DJANGO_SETTINGS_MODULE=config.settings
+uv run citry --app project_explorer.citry_app:citry_app check
 uv run pytest
 ```
+
+In PowerShell:
+
+```powershell
+$env:DJANGO_SETTINGS_MODULE = "config.settings"
+uv run citry --app project_explorer.citry_app:citry_app check
+uv run pytest
+```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/starters/fastapi/.github/workflows/check.yml
+++ b/examples/starters/fastapi/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CITRY_SECRET: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/fastapi/AGENTS.md
+++ b/examples/starters/fastapi/AGENTS.md
@@ -17,7 +17,9 @@
   The app reads the environment directly; `.env.example` records its setup.
 - Treat `State` as browser input. Keep secrets on the server and check
   authorization before returning private data or performing writes.
-- After changes, run `uv run pytest`; the local checks live in `tests/test_app.py`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app app.citry_app:citry_app check`, then run `uv run pytest`.
+  The local tests live in `tests/test_app.py`.
 - For template, CSS, Events, or host changes, run the README server command
   and check the page in a browser. Verify the help button, search results,
   input focus, and browser console and network errors.

--- a/examples/starters/fastapi/README.md
+++ b/examples/starters/fastapi/README.md
@@ -62,9 +62,19 @@ This README remains the source for installation, secret setup, and run commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/starters/flask/.github/workflows/check.yml
+++ b/examples/starters/flask/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CITRY_SECRET: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/flask/AGENTS.md
+++ b/examples/starters/flask/AGENTS.md
@@ -17,7 +17,9 @@
   The app reads the environment directly; `.env.example` records its setup.
 - Treat `State` as browser input. Keep secrets on the server and check
   authorization before returning private data or performing writes.
-- After changes, run `uv run pytest`; the local checks live in `tests/test_app.py`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app app.citry_app:citry_app check`, then run `uv run pytest`.
+  The local tests live in `tests/test_app.py`.
 - For template, CSS, Events, or host changes, run the README server command
   and check the page in a browser. Verify the help button, search results,
   input focus, and browser console and network errors.

--- a/examples/starters/flask/README.md
+++ b/examples/starters/flask/README.md
@@ -65,9 +65,19 @@ This README remains the source for installation, secret setup, and run commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/starters/standalone/.github/workflows/check.yml
+++ b/examples/starters/standalone/.github/workflows/check.yml
@@ -1,0 +1,22 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/standalone/AGENTS.md
+++ b/examples/starters/standalone/AGENTS.md
@@ -14,8 +14,10 @@
 - Keep the generated document self-contained. Alpine interactions run locally;
   Python finishes when the render command exits.
 - Keep secrets and private data out of rendered HTML and browser data.
-- After changes, run `uv run pytest` (tests live in `tests/test_standalone.py`)
-  and `uv run python -m app.render` to produce `_build/index.html`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app app.citry_app:citry_app check`, then run `uv run pytest`
+  (tests live in `tests/test_standalone.py`) and `uv run python -m app.render`
+  to produce `_build/index.html`.
 - For template, CSS, or browser behavior changes, open `_build/index.html`
   in a browser. Check the help button, rendered layout, console errors, and
   that the page works without network requests.

--- a/examples/starters/standalone/README.md
+++ b/examples/starters/standalone/README.md
@@ -53,9 +53,17 @@ This README remains the source for installation and render commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment, test cache, and build
 

--- a/examples/starters/wsgi/.github/workflows/check.yml
+++ b/examples/starters/wsgi/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check the project
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      CITRY_SECRET: ci-only-example-secret
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.12"
+          python-version: "3.14"
+      - name: Install locked dependencies
+        run: uv sync --frozen --dev
+      - name: Check Citry templates
+        run: uv run citry --app app.citry_app:citry_app check
+      - name: Run project tests
+        run: uv run pytest

--- a/examples/starters/wsgi/AGENTS.md
+++ b/examples/starters/wsgi/AGENTS.md
@@ -17,7 +17,9 @@
   The app reads the environment directly; `.env.example` records its setup.
 - Treat `State` as browser input. Keep secrets on the server and check
   authorization before returning private data or performing writes.
-- After changes, run `uv run pytest`; the local checks live in `tests/test_app.py`.
+- After changes, follow the README environment setup, run
+  `uv run citry --app app.citry_app:citry_app check`, then run `uv run pytest`.
+  The local tests live in `tests/test_app.py`.
 - For template, CSS, Events, or host changes, run the README server command
   and check the page in a browser. Verify the help button, search results,
   input focus, and browser console and network errors.

--- a/examples/starters/wsgi/README.md
+++ b/examples/starters/wsgi/README.md
@@ -66,9 +66,19 @@ This README remains the source for installation, secret setup, and run commands.
 
 ## Test the project
 
+Check component templates with the app registry, then run the tests:
+
+Use the environment setup from the run instructions above.
+
 ```console
+uv run citry --app app.citry_app:citry_app check
 uv run pytest
 ```
+
+[The included GitHub Actions workflow](.github/workflows/check.yml) runs
+these checks on pushes and pull requests when you copy this project, including
+its hidden directories, to the root of your own repository. It installs the
+locked dependencies before checking templates and running tests.
 
 ## Remove the environment and test cache
 

--- a/examples/tests/test_archive.py
+++ b/examples/tests/test_archive.py
@@ -18,7 +18,7 @@ def test_archive_is_deterministic_and_contains_only_project_inventory(tmp_path, 
     with tarfile.open(first, "r:gz") as archive:
         names = archive.getnames()
         # Copiers and archive readers must receive the same setup instructions.
-        instructions = ["README.md"]
+        instructions = ["README.md", ".github/workflows/check.yml"]
         if project.kind == "starter":
             instructions.extend(("AGENTS.md", "CLAUDE.md"))
         for relative in instructions:

--- a/examples/tests/test_catalog.py
+++ b/examples/tests/test_catalog.py
@@ -205,3 +205,24 @@ def test_port_placeholder_is_resolved_without_shell_interpolation() -> None:
 
 def test_qualification_commands_keep_the_candidate_install() -> None:
     assert project_environment()["UV_NO_SYNC"] == "1"
+
+
+def test_projects_ship_the_documented_lint_and_test_workflow() -> None:
+    for project in load_catalog():
+        command = " ".join(project.check)
+        assert project.check == ("uv", "run", "citry", "--app", EXPECTED_CITRY_APPS[project.id], "check")
+        workflow = project.source.joinpath(".github/workflows/check.yml").read_text(encoding="utf-8")
+        assert "on: [push, pull_request]" in workflow
+        assert "permissions:\n  contents: read" in workflow
+        assert "run: uv sync --frozen --dev" in workflow
+        assert workflow.index(f"run: {command}") < workflow.index("run: uv run pytest")
+        if project.host == "django":
+            assert "DJANGO_SETTINGS_MODULE: config.settings" in workflow
+            assert "DJANGO_SECRET_KEY:" in workflow
+        elif project.id in ENVIRONMENT_EXAMPLES:
+            assert "CITRY_SECRET:" in workflow
+        readme = project.source.joinpath("README.md").read_text(encoding="utf-8")
+        assert command in readme
+        assert "(.github/workflows/check.yml)" in readme
+        if project.kind == "starter":
+            assert command in project.source.joinpath("AGENTS.md").read_text(encoding="utf-8")

--- a/examples/tests/test_qualification_checks.py
+++ b/examples/tests/test_qualification_checks.py
@@ -1,0 +1,47 @@
+"""Template errors stop clean-copy qualification before tests or server startup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from examples._internal.catalog import CATALOG_PATH, load_catalog
+from examples._internal.qualify import project_environment, qualify_project
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize("project_id", ["starter-standalone", "starter-django"])
+def test_failed_template_check_stops_qualification(tmp_path: Path, project_id: str) -> None:
+    project = next(project for project in load_catalog() if project.id == project_id)
+    environment = project_environment()
+    original = environment.copy()
+    with patch("examples._internal.qualify.run_checked", side_effect=RuntimeError("template error")) as run:
+        with pytest.raises(RuntimeError, match="template error"):
+            qualify_project(project, tmp_path, environment, None, 1)
+    assert run.call_count == 1
+    assert run.call_args.args[:2] == (project.check, tmp_path)
+    checked_environment = run.call_args.args[2]
+    assert checked_environment["UV_NO_SYNC"] == "1"
+    if project.host == "django":
+        assert checked_environment["DJANGO_SETTINGS_MODULE"] == "config.settings"
+    assert environment == original
+
+
+def test_template_checks_precede_tests_and_build(tmp_path: Path) -> None:
+    project = next(project for project in load_catalog() if project.id == "starter-standalone")
+    with patch("examples._internal.qualify.run_checked") as run:
+        qualify_project(project, tmp_path, project_environment(), None, 1)
+    assert [call.args[0] for call in run.call_args_list] == [project.check, project.test, project.build]
+
+
+@pytest.mark.parametrize("replacement", ["", "check = []", 'check = "uv run citry check"'])
+def test_catalog_rejects_missing_or_malformed_check(tmp_path: Path, replacement: str) -> None:
+    source = CATALOG_PATH.read_text(encoding="utf-8")
+    command = next(line for line in source.splitlines() if line.startswith("check = "))
+    catalog = tmp_path / "catalog.toml"
+    catalog.write_text(source.replace(command, replacement, 1), encoding="utf-8")
+    with pytest.raises(ValueError, match="check"):
+        load_catalog(catalog)


### PR DESCRIPTION
All six starters and both demos now ship a GitHub Actions workflow that runs the app-aware Citry template checker before pytest. Their READMEs and starter agent instructions show the same local command, and the monorepo clean-copy qualifier runs it too, so archived examples exercise the documented path.

Validation: all eight projects passed with their frozen Citry 0.4.6 dependencies and with the published Citry 0.5.0/Core 1.7.0 artifacts; 30 example-tool tests passed. Ruff, formatting and independent technical/prose reviews passed. Dependency declarations and locks are unchanged.
