### PR TITLE
Fix candidate Citry Core wheels for Python smoke matrices

### DIFF
--- a/.github/workflows/py--citry-lsp--publish.yml
+++ b/.github/workflows/py--citry-lsp--publish.yml
@@ -73,6 +73,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_commit }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
@@ -87,7 +90,8 @@ jobs:
           mkdir -p candidate-dependencies
           if [[ "$selected" == *,citry-core,* ]]; then
             git submodule update --init --recursive
-            uv build --package citry-core --wheel --out-dir candidate-dependencies
+            uv build --package citry-core --wheel --out-dir candidate-dependencies \
+              --config-setting 'maturin.build-args=--features abi3-py310'
           fi
           if [[ "$selected" == *,citry,* ]]; then
             uv build --package citry --wheel --out-dir candidate-dependencies

--- a/.github/workflows/py--citry-ui--publish.yml
+++ b/.github/workflows/py--citry-ui--publish.yml
@@ -73,6 +73,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.release_commit }}
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
@@ -98,7 +101,8 @@ jobs:
           mkdir -p candidate-dependencies
           if [[ "$selected" == *,citry-core,* ]]; then
             git submodule update --init --recursive
-            uv build --package citry-core --wheel --out-dir candidate-dependencies
+            uv build --package citry-core --wheel --out-dir candidate-dependencies \
+              --config-setting 'maturin.build-args=--features abi3-py310'
           fi
           if [[ "$selected" == *,citry,* ]]; then
             uv build --package citry --wheel --out-dir candidate-dependencies

--- a/packages/py/citry/tests/test_release_dependency_wheels.py
+++ b/packages/py/citry/tests/test_release_dependency_wheels.py
@@ -1,0 +1,47 @@
+"""Contracts for native candidate dependencies used by release smoke matrices."""
+
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+
+def test_multi_version_cpython_smokes_build_selected_core_as_abi3() -> None:
+    checked: set[str] = set()
+
+    for path in _WORKFLOWS.glob("py--*-publish.yml"):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        jobs = workflow["jobs"]
+        smoke = jobs.get("smoke-python")
+        if smoke is None:
+            continue
+        versions = smoke.get("strategy", {}).get("matrix", {}).get("python-version", [])
+        if len(versions) < 2:
+            continue
+
+        core_builds = [
+            step["run"]
+            for step in jobs["build"]["steps"]
+            if "uv build --package citry-core --wheel" in step.get("run", "")
+        ]
+        if not core_builds:
+            continue
+
+        build_pythons = [
+            step["with"]["python-version"]
+            for step in jobs["build"]["steps"]
+            if step.get("uses") == "actions/setup-python@v7"
+        ]
+        assert versions == ["3.10", "3.11", "3.12", "3.13", "3.14"], path.name
+        assert build_pythons == ["3.14"], path.name
+        assert len(core_builds) == 1, path.name
+        assert "--config-setting 'maturin.build-args=--features abi3-py310'" in core_builds[0], path.name
+        checked.add(path.name)
+
+    assert checked == {
+        "py--citry--publish.yml",
+        "py--citry-lsp--publish.yml",
+        "py--citry-ui--publish.yml",
+    }


### PR DESCRIPTION
Candidate 34646253547 built the selected Citry Core dependency with the build runner's CPython 3.12, then passed that `cp312-cp312` wheel to every Citry LSP smoke job from Python 3.10 through 3.14. The non-3.12 jobs rejected the incompatible wheel before the package smoke could run.

Pin the dependency build to normal CPython 3.14 and enable Citry Core's established `abi3-py310` feature, producing one platform-specific `cp310-abi3` wheel compatible with the full CPython matrix. Apply the same correction to Citry UI's equivalent multi-version candidate path, and enforce the rule across Citry, Citry LSP, and Citry UI release workers with a workflow contract test.

Validation:
- 34 focused release workflow/controller/security tests
- Ruff formatting and lint
- mypy
- workflow YAML parsing and repository validators
- local `cp310-abi3` build installed and loaded under CPython 3.10 and 3.14
