### PR TITLE
Add targeted Python diagnostics and cancel stale PR runs

### DIFF
--- a/.github/workflows/py--diagnostic.yml
+++ b/.github/workflows/py--diagnostic.yml
@@ -1,0 +1,69 @@
+# Run one ordinary non-browser Python test target for focused diagnosis.
+name: Python diagnostic
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_os:
+        description: Hosted runner operating system
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+      python_version:
+        description: Supported Python version
+        required: true
+        default: "3.14"
+        type: choice
+        options:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+      pytest_target:
+        description: One ordinary non-browser Python test file or node ID
+        required: true
+        default: packages/py/citry/tests/test_server_reload.py
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ inputs.runner_os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install the workspace
+        run: uv sync --locked --all-packages
+
+      - name: Run selected pytest target serially
+        shell: bash
+        env:
+          PYTEST_TARGET: ${{ inputs.pytest_target }}
+        run: uv run --no-sync pytest --durations 30 -- "$PYTEST_TARGET"

--- a/.github/workflows/py--examples--tests.yml
+++ b/.github/workflows/py--examples--tests.yml
@@ -42,8 +42,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: examples-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 
 jobs:
   clean-copy:

--- a/.github/workflows/py--tests.yml
+++ b/.github/workflows/py--tests.yml
@@ -66,6 +66,9 @@ on:
       - ".gitmodules"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 jobs:
   i18n-release-qualification:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo--check.yml
+++ b/.github/workflows/repo--check.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo--dependabot-relock.yml
+++ b/.github/workflows/repo--dependabot-relock.yml
@@ -26,6 +26,9 @@ on:
       - "pyproject.toml"
       - "packages/py/*/pyproject.toml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 permissions:
   contents: read # the push uses the App/PAT token, not GITHUB_TOKEN
   pull-requests: write # for the fallback comment via GITHUB_TOKEN

--- a/.github/workflows/repo--discord-pr.yml
+++ b/.github/workflows/repo--discord-pr.yml
@@ -9,6 +9,9 @@ on:
   pull_request_target:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo--docs-check.yml
+++ b/.github/workflows/repo--docs-check.yml
@@ -68,6 +68,9 @@ on:
       - ".gitmodules"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 permissions:
   contents: read
 

--- a/.github/workflows/repo--docs-lighthouse.yml
+++ b/.github/workflows/repo--docs-lighthouse.yml
@@ -47,6 +47,9 @@ on:
       - ".github/lighthouserc.citry-ui.json"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 permissions:
   contents: read
 

--- a/.github/workflows/rust--tests.yml
+++ b/.github/workflows/rust--tests.yml
@@ -26,6 +26,9 @@ on:
       - ".gitmodules"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -554,6 +554,40 @@ selected in the same plan. This qualifies the unreleased pair concurrently.
 During promotion, the controller still publishes and verifies Core before it
 starts Citry, whose public dependency must then resolve to those exact bytes.
 
+### Pull request cancellation and targeted diagnostics
+
+Each pull-request workflow uses a concurrency group containing the workflow
+name and pull-request number. A newer run cancels an older run for the same
+pull request. Push and manual runs use their unique run IDs, so this policy
+does not interrupt or replace them.
+
+Use [`py--diagnostic.yml`](../.github/workflows/py--diagnostic.yml) to reproduce
+one Python failure on a selected hosted OS and supported Python version. In the
+GitHub Actions UI, open **Python diagnostic**, choose **Run workflow**, select
+the branch or tag, then set `runner_os`, `python_version`, and one file or node
+ID from the ordinary non-browser Python test suite in `pytest_target`. The
+target is passed to pytest as one literal argument, so this workflow does not
+accept multiple targets or extra pytest options. Its workspace installation
+does not include the optional browser, documentation, or benchmark dependency
+groups.
+
+The equivalent command-line dispatch is:
+
+```bash
+gh workflow run py--diagnostic.yml \
+  --ref review \
+  -f runner_os=macos-latest \
+  -f python_version=3.14 \
+  -f pytest_target='packages/py/citry/tests/test_server_reload.py::test_development_server_hot_reloads_assets_and_restarts_python[django]'
+```
+
+Start CI investigation with the narrowest failing node ID, and repeat that
+target while diagnosing. After the fix passes focused local checks, run
+`python scripts/check.py --profile full` once at the final integration
+boundary and let the ordinary pull-request workflows provide the required
+matrix and browser evidence. A green diagnostic run is supporting evidence;
+it does not replace the full gate.
+
 ### Adding a codebase-wide tooling package
 
 To add a new tooling dependency (like a linter, formatter, or test utility) that should be available across the entire codebase:

--- a/packages/py/citry/tests/test_ci_workflows.py
+++ b/packages/py/citry/tests/test_ci_workflows.py
@@ -1,0 +1,91 @@
+"""Contracts for pull-request cancellation and focused Python diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    content = yaml.safe_load((_WORKFLOWS / name).read_text(encoding="utf-8"))
+    assert isinstance(content, dict)
+    # PyYAML applies YAML 1.1 booleans, where the Actions key `on` becomes True.
+    if True in content:
+        content["on"] = content.pop(True)
+    return content
+
+
+def test_pull_request_workflows_cancel_only_stale_pull_request_runs() -> None:
+    checked: set[str] = set()
+    workflow_paths = [*_WORKFLOWS.glob("*.yml"), *_WORKFLOWS.glob("*.yaml")]
+    for path in workflow_paths:
+        workflow = _load_workflow(path.name)
+        events = workflow.get("on", {})
+        if not isinstance(events, dict) or not {"pull_request", "pull_request_target"}.intersection(events):
+            continue
+
+        assert workflow.get("concurrency") == {
+            "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}",
+            "cancel-in-progress": (
+                "${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}"
+            ),
+        }, path.name
+        checked.add(path.name)
+
+    assert checked == {
+        "py--examples--tests.yml",
+        "py--tests.yml",
+        "repo--check.yml",
+        "repo--dependabot-relock.yml",
+        "repo--discord-pr.yml",
+        "repo--docs-check.yml",
+        "repo--docs-lighthouse.yml",
+        "rust--tests.yml",
+    }
+
+
+def test_python_diagnostic_constrains_setup_and_passes_one_literal_target() -> None:
+    workflow = _load_workflow("py--diagnostic.yml")
+    dispatch = workflow["on"]["workflow_dispatch"]
+    inputs = dispatch["inputs"]
+
+    runner = inputs["runner_os"]
+    assert runner["type"] == "choice"
+    assert runner["required"] is True
+    assert runner["default"] == "ubuntu-latest"
+    assert runner["options"] == ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    python = inputs["python_version"]
+    assert python["type"] == "choice"
+    assert python["required"] is True
+    assert python["default"] == "3.14"
+    assert python["options"] == ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    target = inputs["pytest_target"]
+    assert target == {
+        "description": "One ordinary non-browser Python test file or node ID",
+        "required": True,
+        "default": "packages/py/citry/tests/test_server_reload.py",
+        "type": "string",
+    }
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert set(workflow["jobs"]) == {"test"}
+    job = workflow["jobs"]["test"]
+    assert job["runs-on"] == "${{ inputs.runner_os }}"
+    steps = {step.get("name", step.get("uses")): step for step in job["steps"]}
+    assert steps["actions/checkout@v7"]["with"]["submodules"] == "recursive"
+    assert steps["Set up Python"]["with"]["python-version"] == "${{ inputs.python_version }}"
+    assert steps["Install the workspace"]["run"] == "uv sync --locked --all-packages"
+
+    run_step = steps["Run selected pytest target serially"]
+    assert run_step["shell"] == "bash"
+    assert run_step["env"] == {"PYTEST_TARGET": "${{ inputs.pytest_target }}"}
+    assert "inputs.pytest_target" not in run_step["run"]
+    assert run_step["run"] == 'uv run --no-sync pytest --durations 30 -- "$PYTEST_TARGET"'
+    assert "-n" not in run_step["run"].split()


### PR DESCRIPTION
Pull-request workflows currently let superseded runs continue consuming hosted runners, while reproducing one platform-specific Python failure requires rerunning the broad matrix.

Group every pull-request workflow by workflow and PR number and cancel superseded PR runs, while giving push and manual runs unique groups. Add a manually dispatched Python diagnostic workflow that runs one ordinary non-browser test file or node ID on a constrained hosted OS/Python choice, passing the target as one literal pytest argument. The codebase guide documents targeted diagnosis followed by the final full gate.

Validation:
- 6 focused workflow and gate contract tests
- all 27 workflow YAML files parsed
- Ruff and mypy
- semantic comparison with reviewed commit `b053c331`
- `git diff --check`
