### PR TITLE
ci: cache exact Core wheels for diagnostics

### DIFF
--- a/.github/workflows/py--diagnostic.yml
+++ b/.github/workflows/py--diagnostic.yml
@@ -124,6 +124,17 @@ jobs:
               (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
+      # GITHUB_ENV makes the GitHub Actions cache settings available to both
+      # the native build and sccache's registered post step.
+      - name: Enable GitHub Actions-backed sccache
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
+        shell: bash
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+
       - name: Build Citry Core wheel
         if: >-
           ${{ inputs.install_profile != 'pygments-citry' &&
@@ -132,9 +143,10 @@ jobs:
           CARGO_INCREMENTAL: "0"
           RUSTC_WRAPPER: sccache
           SCCACHE_GHA_ENABLED: "true"
-        run: >-
-          uv build --locked --package citry-core --wheel
-          --out-dir .diagnostic-cache/citry-core
+        run: |
+          uv lock --check
+          uv build --package citry-core --wheel \
+            --out-dir .diagnostic-cache/citry-core
 
       - name: Record built Core wheel identity
         if: >-

--- a/.github/workflows/py--diagnostic.yml
+++ b/.github/workflows/py--diagnostic.yml
@@ -24,6 +24,26 @@ on:
           - "3.12"
           - "3.13"
           - "3.14"
+      install_profile:
+        description: Package test dependencies to install
+        required: true
+        default: citry
+        type: choice
+        options:
+          - citry
+          - citry-core
+          - citry-lsp
+          - citry-ui
+          - pygments-citry
+          - full-workspace
+      core_wheel_mode:
+        description: Reuse the exact Citry Core wheel cache or rebuild through sccache
+        required: true
+        default: reuse
+        type: choice
+        options:
+          - reuse
+          - rebuild
       pytest_target:
         description: One ordinary non-browser Python test file or node ID
         required: true
@@ -36,34 +56,145 @@ permissions:
 jobs:
   test:
     runs-on: ${{ inputs.runner_os }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
 
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python_version }}
 
+      - name: Validate the selected pytest target
+        shell: bash
+        env:
+          INSTALL_PROFILE: ${{ inputs.install_profile }}
+          PYTEST_TARGET: ${{ inputs.pytest_target }}
+        run: >-
+          python scripts/python_diagnostic.py validate-target
+          --profile "$INSTALL_PROFILE"
+          --target "$PYTEST_TARGET"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      # The moving nightly is part of the wheel identity. Resolve the actual
+      # compiler before cache lookup so a newly published nightly cannot reuse
+      # artifacts produced by an older compiler under the same channel name.
       - name: Install Rust toolchain
+        if: ${{ inputs.install_profile != 'pygments-citry' }}
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+      - name: Resolve Citry Core wheel identity
+        if: ${{ inputs.install_profile != 'pygments-citry' }}
+        id: core-identity
+        shell: bash
+        env:
+          RUNNER_ARCH: ${{ runner.arch }}
+          RUNNER_OS: ${{ runner.os }}
+        run: >-
+          python scripts/python_diagnostic.py cache-identity
+          --runner-os "$RUNNER_OS"
+          --runner-arch "$RUNNER_ARCH"
+          --runner-image "${ImageOS:?missing hosted image OS}/${ImageVersion:?missing hosted image version}"
+          --github-output "$GITHUB_OUTPUT"
 
-      - name: Install the workspace
-        run: uv sync --locked --all-packages
+      - name: Restore exact Citry Core wheel
+        if: ${{ inputs.install_profile != 'pygments-citry' && inputs.core_wheel_mode == 'reuse' }}
+        id: core-wheel
+        uses: actions/cache/restore@v6
+        with:
+          path: .diagnostic-cache/citry-core
+          key: ${{ steps.core-identity.outputs.cache_key }}
+
+      - name: Initialize native submodules
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
+        shell: bash
+        run: git submodule update --init --recursive
+
+      - name: Set up sccache for a Core wheel cache miss
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+
+      - name: Build Citry Core wheel
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "true"
+        run: >-
+          uv build --locked --package citry-core --wheel
+          --out-dir .diagnostic-cache/citry-core
+
+      - name: Record built Core wheel identity
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              (inputs.core_wheel_mode == 'rebuild' || steps.core-wheel.outputs.cache-hit != 'true') }}
+        shell: bash
+        env:
+          CORE_WHEEL_CACHE_KEY: ${{ steps.core-identity.outputs.cache_key }}
+        run: >-
+          python scripts/python_diagnostic.py record-wheel
+          --wheel-dir .diagnostic-cache/citry-core
+          --cache-key "$CORE_WHEEL_CACHE_KEY"
+
+      - name: Install selected diagnostic profile
+        shell: bash
+        env:
+          CORE_WHEEL_CACHE_KEY: ${{ steps.core-identity.outputs.cache_key }}
+          INSTALL_PROFILE: ${{ inputs.install_profile }}
+        run: >-
+          python scripts/python_diagnostic.py install-profile
+          --profile "$INSTALL_PROFILE"
+          --wheel-dir .diagnostic-cache/citry-core
+          --cache-key "$CORE_WHEEL_CACHE_KEY"
+
+      # The profile install verifies the manifest, installs the wheel, and
+      # imports its extension before this immutable cache entry is created.
+      # Saving before pytest preserves the build when diagnosis finds a failure.
+      - name: Save exact Citry Core wheel
+        if: >-
+          ${{ inputs.install_profile != 'pygments-citry' &&
+              inputs.core_wheel_mode == 'reuse' &&
+              steps.core-wheel.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: .diagnostic-cache/citry-core
+          key: ${{ steps.core-identity.outputs.cache_key }}
+
+      - name: Report diagnostic setup
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.core-wheel.outputs.cache-hit }}
+          CORE_WHEEL_MODE: ${{ inputs.core_wheel_mode }}
+          INSTALL_PROFILE: ${{ inputs.install_profile }}
+        run: |
+          if [[ "$INSTALL_PROFILE" == "pygments-citry" ]]; then
+            wheel_result="not required"
+          elif [[ "$CORE_WHEEL_MODE" == "rebuild" ]]; then
+            wheel_result="forced rebuild (sccache enabled)"
+          elif [[ "$CACHE_HIT" == "true" ]]; then
+            wheel_result="exact wheel cache hit"
+          else
+            wheel_result="wheel cache miss (built with sccache)"
+          fi
+          echo "Profile: $INSTALL_PROFILE; Citry Core: $wheel_result"
+          echo "### Python diagnostic setup" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Profile: \`$INSTALL_PROFILE\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Citry Core: $wheel_result" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run selected pytest target serially
         shell: bash
         env:
           PYTEST_TARGET: ${{ inputs.pytest_target }}
-        run: uv run --no-sync pytest --durations 30 -- "$PYTEST_TARGET"
+        run: uv run --no-sync python -m pytest -m "not e2e" --durations 30 -- "$PYTEST_TARGET"

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -618,6 +618,10 @@ exercises the native build through `sccache`; use it when the build itself is
 under investigation. The setup result appears in both the job log and job
 summary.
 
+The build first runs `uv lock --check` to verify the Python workspace lock.
+The Core package also sets `tool.maturin.locked = true`, so Cargo verifies and
+uses `Cargo.lock` while building the native extension.
+
 GitHub scopes Actions caches by key, cache version, and branch. Repeated runs
 on one investigation branch can reuse that branch's exact wheel. A matching
 cache populated on the default branch is also available to other branches,

--- a/docs/codebase.md
+++ b/docs/codebase.md
@@ -562,14 +562,27 @@ pull request. Push and manual runs use their unique run IDs, so this policy
 does not interrupt or replace them.
 
 Use [`py--diagnostic.yml`](../.github/workflows/py--diagnostic.yml) to reproduce
-one Python failure on a selected hosted OS and supported Python version. In the
-GitHub Actions UI, open **Python diagnostic**, choose **Run workflow**, select
-the branch or tag, then set `runner_os`, `python_version`, and one file or node
-ID from the ordinary non-browser Python test suite in `pytest_target`. The
-target is passed to pytest as one literal argument, so this workflow does not
-accept multiple targets or extra pytest options. Its workspace installation
-does not include the optional browser, documentation, or benchmark dependency
-groups.
+one Python failure on a selected hosted OS and supported Python version. Its
+default `citry` profile on `ubuntu-latest` installs Citry and Citry's test
+dependencies, plus the small root tooling group used by Citry's repository
+policy tests. Select `citry-core`, `citry-lsp`, `citry-ui`, or
+`pygments-citry` when the target belongs to another package. `full-workspace`
+installs every package's development environment for failures that depend on
+their interactions. None of the profiles installs browser, documentation, or
+benchmark dependency groups.
+
+A package profile installs that package's declared development dependencies.
+Tests for optional host integrations may skip when their optional host is not
+part of that profile. Select `full-workspace` when the missing host interaction
+is what the diagnostic needs to exercise.
+
+In the GitHub Actions UI, open **Python diagnostic**, choose **Run workflow**,
+select the branch or tag, then set `runner_os`, `python_version`,
+`install_profile`, `core_wheel_mode`, and `pytest_target`. The target must be
+an existing `test_*.py` file or node ID inside the selected package. The
+validator rejects browser and benchmark paths, cross-profile paths, path
+traversal, multiple targets, and pytest options. The validated value is passed
+to pytest as one literal argument, and pytest also excludes the `e2e` marker.
 
 The equivalent command-line dispatch is:
 
@@ -578,8 +591,39 @@ gh workflow run py--diagnostic.yml \
   --ref review \
   -f runner_os=macos-latest \
   -f python_version=3.14 \
+  -f install_profile=citry \
+  -f core_wheel_mode=reuse \
   -f pytest_target='packages/py/citry/tests/test_server_reload.py::test_development_server_hot_reloads_assets_and_restarts_python[django]'
 ```
+
+Profiles that import Citry Core tell `uv sync` to omit the editable Core
+package. Setup then installs the exact cached or newly built wheel. The wheel
+key includes the hosted runner image version, OS, and architecture; the full
+Python runtime and ABI; the resolved `rustc -Vv` and uv versions; and a digest
+of the tracked Cargo workspace, Rust sources, Ruff submodule commit, Core
+package contents, lockfiles, and toolchain configuration. The digest also
+covers the workflow and its setup helper, so a build-recipe change cannot reuse
+a wheel built by the previous recipe. There are no prefix restore keys: only
+an exact match can be installed. A manifest beside the wheel records its cache
+key, filename, and SHA-256 digest. Setup verifies all three, installs the
+wheel, and imports its extension before a new cache entry can be saved.
+
+On an exact wheel hit, the workflow skips submodule initialization and native
+compilation. On a miss, it initializes the Ruff submodule, enables the GitHub
+Actions backend for `sccache`, builds the wheel, records its manifest, and
+installs and imports it. In reuse mode, the workflow then saves the verified
+wheel before pytest runs. This timing preserves the build when the selected
+diagnostic test fails. `core_wheel_mode=rebuild` bypasses the wheel cache and
+exercises the native build through `sccache`; use it when the build itself is
+under investigation. The setup result appears in both the job log and job
+summary.
+
+GitHub scopes Actions caches by key, cache version, and branch. Repeated runs
+on one investigation branch can reuse that branch's exact wheel. A matching
+cache populated on the default branch is also available to other branches,
+but a wheel first saved on one feature branch is not a general cross-branch
+cache for sibling branches. Cache eviction can still turn a later run into a
+safe miss and rebuild.
 
 Start CI investigation with the narrowest failing node ID, and repeat that
 target while diagnosing. After the fix passes focused local checks, run

--- a/packages/py/citry/tests/test_ci_workflows.py
+++ b/packages/py/citry/tests/test_ci_workflows.py
@@ -66,6 +66,25 @@ def test_python_diagnostic_constrains_setup_and_passes_one_literal_target() -> N
     assert python["default"] == "3.14"
     assert python["options"] == ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
+    profile = inputs["install_profile"]
+    assert profile["type"] == "choice"
+    assert profile["required"] is True
+    assert profile["default"] == "citry"
+    assert profile["options"] == [
+        "citry",
+        "citry-core",
+        "citry-lsp",
+        "citry-ui",
+        "pygments-citry",
+        "full-workspace",
+    ]
+
+    wheel_mode = inputs["core_wheel_mode"]
+    assert wheel_mode["type"] == "choice"
+    assert wheel_mode["required"] is True
+    assert wheel_mode["default"] == "reuse"
+    assert wheel_mode["options"] == ["reuse", "rebuild"]
+
     target = inputs["pytest_target"]
     assert target == {
         "description": "One ordinary non-browser Python test file or node ID",
@@ -78,14 +97,65 @@ def test_python_diagnostic_constrains_setup_and_passes_one_literal_target() -> N
     assert set(workflow["jobs"]) == {"test"}
     job = workflow["jobs"]["test"]
     assert job["runs-on"] == "${{ inputs.runner_os }}"
+    assert job["timeout-minutes"] == 45
     steps = {step.get("name", step.get("uses")): step for step in job["steps"]}
-    assert steps["actions/checkout@v7"]["with"]["submodules"] == "recursive"
+    assert "with" not in steps["actions/checkout@v7"]
     assert steps["Set up Python"]["with"]["python-version"] == "${{ inputs.python_version }}"
-    assert steps["Install the workspace"]["run"] == "uv sync --locked --all-packages"
+
+    validate_step = steps["Validate the selected pytest target"]
+    assert validate_step["shell"] == "bash"
+    assert validate_step["env"] == {
+        "INSTALL_PROFILE": "${{ inputs.install_profile }}",
+        "PYTEST_TARGET": "${{ inputs.pytest_target }}",
+    }
+    assert "inputs.pytest_target" not in validate_step["run"]
+    assert 'validate-target --profile "$INSTALL_PROFILE" --target "$PYTEST_TARGET"' in validate_step["run"]
+
+    restore = steps["Restore exact Citry Core wheel"]
+    assert restore["uses"] == "actions/cache/restore@v6"
+    assert restore["with"] == {
+        "path": ".diagnostic-cache/citry-core",
+        "key": "${{ steps.core-identity.outputs.cache_key }}",
+    }
+    assert "restore-keys" not in restore["with"]
+    identity = steps["Resolve Citry Core wheel identity"]
+    runner_image_argument = (
+        'runner-image "${ImageOS:?missing hosted image OS}/${ImageVersion:?missing hosted image version}"'
+    )
+    assert runner_image_argument in identity["run"]
+
+    build = steps["Build Citry Core wheel"]
+    assert build["env"] == {
+        "CARGO_INCREMENTAL": "0",
+        "RUSTC_WRAPPER": "sccache",
+        "SCCACHE_GHA_ENABLED": "true",
+    }
+    assert "uv build --locked --package citry-core --wheel" in build["run"]
+    assert steps["Set up sccache for a Core wheel cache miss"]["uses"] == (
+        "mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba"
+    )
+    assert steps["Initialize native submodules"]["run"] == "git submodule update --init --recursive"
+
+    save = steps["Save exact Citry Core wheel"]
+    assert save["uses"] == "actions/cache/save@v6"
+    assert save["with"] == restore["with"]
+    assert "core_wheel_mode == 'reuse'" in save["if"]
+    assert "cache-hit != 'true'" in save["if"]
+    step_names = [step.get("name", step.get("uses")) for step in job["steps"]]
+    assert step_names.index("Install selected diagnostic profile") < step_names.index("Save exact Citry Core wheel")
+    assert step_names.index("Save exact Citry Core wheel") < step_names.index("Run selected pytest target serially")
+
+    install = steps["Install selected diagnostic profile"]
+    assert install["env"] == {
+        "CORE_WHEEL_CACHE_KEY": "${{ steps.core-identity.outputs.cache_key }}",
+        "INSTALL_PROFILE": "${{ inputs.install_profile }}",
+    }
+    assert "inputs.install_profile" not in install["run"]
+    assert 'install-profile --profile "$INSTALL_PROFILE"' in install["run"]
 
     run_step = steps["Run selected pytest target serially"]
     assert run_step["shell"] == "bash"
     assert run_step["env"] == {"PYTEST_TARGET": "${{ inputs.pytest_target }}"}
     assert "inputs.pytest_target" not in run_step["run"]
-    assert run_step["run"] == 'uv run --no-sync pytest --durations 30 -- "$PYTEST_TARGET"'
+    assert run_step["run"] == 'uv run --no-sync python -m pytest -m "not e2e" --durations 30 -- "$PYTEST_TARGET"'
     assert "-n" not in run_step["run"].split()

--- a/packages/py/citry/tests/test_ci_workflows.py
+++ b/packages/py/citry/tests/test_ci_workflows.py
@@ -157,9 +157,7 @@ def test_python_diagnostic_constrains_setup_and_passes_one_literal_target() -> N
     uv = shutil.which("uv")
     assert uv is not None
     uv_build_help = subprocess.run([uv, "build", "--help"], check=True, capture_output=True, text=True).stdout
-    supported_build_options = set(
-        re.findall(r"(?m)^\s+(?:-[A-Za-z],\s+)?(--[a-z][a-z-]*)\b", uv_build_help)
-    )
+    supported_build_options = set(re.findall(r"(?m)^\s+(?:-[A-Za-z],\s+)?(--[a-z][a-z-]*)\b", uv_build_help))
     build_command = " ".join(build["run"].splitlines()[1:]).replace("\\", "")
     requested_build_options = {token for token in shlex.split(build_command) if token.startswith("--")}
     assert requested_build_options <= supported_build_options

--- a/packages/py/citry/tests/test_ci_workflows.py
+++ b/packages/py/citry/tests/test_ci_workflows.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
+import re
+import shlex
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore[import-untyped]
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-untyped, no-redef]
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
@@ -130,11 +140,34 @@ def test_python_diagnostic_constrains_setup_and_passes_one_literal_target() -> N
         "RUSTC_WRAPPER": "sccache",
         "SCCACHE_GHA_ENABLED": "true",
     }
-    assert "uv build --locked --package citry-core --wheel" in build["run"]
+    assert build["run"].splitlines() == [
+        "uv lock --check",
+        "uv build --package citry-core --wheel \\",
+        "  --out-dir .diagnostic-cache/citry-core",
+    ]
     assert steps["Set up sccache for a Core wheel cache miss"]["uses"] == (
         "mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba"
     )
+    assert steps["Enable GitHub Actions-backed sccache"]["run"].splitlines() == [
+        'echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"',
+        'echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"',
+    ]
     assert steps["Initialize native submodules"]["run"] == "git submodule update --init --recursive"
+
+    uv = shutil.which("uv")
+    assert uv is not None
+    uv_build_help = subprocess.run([uv, "build", "--help"], check=True, capture_output=True, text=True).stdout
+    supported_build_options = set(
+        re.findall(r"(?m)^\s+(?:-[A-Za-z],\s+)?(--[a-z][a-z-]*)\b", uv_build_help)
+    )
+    build_command = " ".join(build["run"].splitlines()[1:]).replace("\\", "")
+    requested_build_options = {token for token in shlex.split(build_command) if token.startswith("--")}
+    assert requested_build_options <= supported_build_options
+
+    core_pyproject = tomllib.loads(
+        (_REPO_ROOT / "packages" / "py" / "citry_core" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert core_pyproject["tool"]["maturin"]["locked"] is True
 
     save = steps["Save exact Citry Core wheel"]
     assert save["uses"] == "actions/cache/save@v6"

--- a/packages/py/citry/tests/test_python_diagnostic.py
+++ b/packages/py/citry/tests/test_python_diagnostic.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from scripts import python_diagnostic
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("profile", "relative_target"),
+    [
+        ("citry", "packages/py/citry/tests/test_reload.py"),
+        ("citry-core", "packages/py/citry_core/tests/test_template_parser.py::test_compile"),
+        ("citry-lsp", "packages/py/citry_lsp/tests/test_engine.py"),
+        ("citry-ui", "packages/py/citry_ui/citry_ui/quality/tests/test_scaling.py"),
+        ("pygments-citry", "packages/py/pygments_citry/tests/test_lexers.py"),
+        ("full-workspace", "packages/py/citry_lsp/tests/test_engine.py::TestEngine::test_open"),
+    ],
+)
+def test_validate_pytest_target_accepts_profile_files_and_node_ids(
+    tmp_path: Path,
+    profile: str,
+    relative_target: str,
+) -> None:
+    relative_file = relative_target.partition("::")[0]
+    target = tmp_path / relative_file
+    target.parent.mkdir(parents=True)
+    target.touch()
+
+    assert python_diagnostic.validate_pytest_target(profile, relative_target, repo_root=tmp_path) == target
+
+
+@pytest.mark.parametrize(
+    ("profile", "target"),
+    [
+        ("citry", "packages/py/citry_core/tests/test_template_parser.py"),
+        ("citry", "packages/py/citry/tests/e2e/test_runtime_e2e.py"),
+        ("citry", "packages/py/citry/tests/test_benchmark_citry.py"),
+        ("citry", "packages/py/citry/citry/reload.py"),
+        ("citry", "../test_escape.py"),
+        ("citry", "--collect-only"),
+        ("citry", "packages/py/citry/tests/test_reload.py\n--collect-only"),
+        ("citry", "packages/py/citry/tests/test_reload.py::"),
+    ],
+)
+def test_validate_pytest_target_rejects_cross_profile_browser_and_nonliteral_targets(
+    tmp_path: Path,
+    profile: str,
+    target: str,
+) -> None:
+    file_target = target.partition("::")[0]
+    candidate = tmp_path / file_target
+    if file_target.startswith("packages/") and "\n" not in target:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.touch(exist_ok=True)
+
+    with pytest.raises(ValueError, match=r"pytest target|pytest node|browser and benchmark"):
+        python_diagnostic.validate_pytest_target(profile, target, repo_root=tmp_path)
+
+
+def test_native_source_digest_tracks_build_inputs_but_ignores_tracked_nonbuild_paths(tmp_path: Path) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    subprocess.run([git, "init", "-q"], cwd=tmp_path, check=True)
+    cargo = tmp_path / "Cargo.toml"
+    cargo.write_text("[workspace]\n", encoding="utf-8")
+    subprocess.run([git, "add", "Cargo.toml"], cwd=tmp_path, check=True)
+    original = python_diagnostic.native_source_digest(repo_root=tmp_path)
+
+    source = tmp_path / "crates" / "demo" / "src" / "lib.rs"
+    source.parent.mkdir(parents=True)
+    source.write_text("pub fn one() {}\n", encoding="utf-8")
+    subprocess.run([git, "add", "crates/demo/src/lib.rs"], cwd=tmp_path, check=True)
+    changed = python_diagnostic.native_source_digest(repo_root=tmp_path)
+    assert changed != original
+
+    unrelated = tmp_path / "crates" / "demo" / "tests" / "test_demo.rs"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("ignored\n", encoding="utf-8")
+    subprocess.run([git, "add", "crates/demo/tests/test_demo.rs"], cwd=tmp_path, check=True)
+    assert python_diagnostic.native_source_digest(repo_root=tmp_path) == changed
+
+
+def test_citry_profile_selects_the_root_owner_of_its_policy_test_dependencies() -> None:
+    assert python_diagnostic._SYNC_ARGUMENTS["citry"] == (
+        "--package",
+        "citry-monorepo",
+        "--package",
+        "citry",
+    )
+    root_pyproject = (python_diagnostic._REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"pyyaml>=6.0"' in root_pyproject
+
+
+def test_cache_identity_is_scoped_by_runner_python_compiler_and_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rustc_identity = ["rustc one", "rust-one"]
+    source_digest = ["source-one"]
+    python_version = ["3.14.0"]
+    monkeypatch.setattr(python_diagnostic, "_rustc_identity", lambda: tuple(rustc_identity))
+    monkeypatch.setattr(python_diagnostic, "_uv_identity", lambda: "uv 1")
+    monkeypatch.setattr(python_diagnostic, "native_source_digest", lambda **_kwargs: source_digest[0])
+    monkeypatch.setattr(python_diagnostic.platform, "python_version", lambda: python_version[0])
+    monkeypatch.setattr(python_diagnostic.sysconfig, "get_config_var", lambda _name: "cpython-314-linux")
+
+    base = python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/one", repo_root=tmp_path)["cache_key"]
+    assert python_diagnostic.cache_identity("macOS", "X64", "macos-15/one", repo_root=tmp_path)["cache_key"] != base
+    assert python_diagnostic.cache_identity("Linux", "ARM64", "ubuntu24/one", repo_root=tmp_path)["cache_key"] != base
+    assert python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/two", repo_root=tmp_path)["cache_key"] != base
+
+    python_version[0] = "3.14.1"
+    assert python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/one", repo_root=tmp_path)["cache_key"] != base
+    python_version[0] = "3.14.0"
+
+    rustc_identity[:] = ["rustc two", "rust-two"]
+    assert python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/one", repo_root=tmp_path)["cache_key"] != base
+    rustc_identity[:] = ["rustc one", "rust-one"]
+
+    source_digest[0] = "source-two"
+    assert python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/one", repo_root=tmp_path)["cache_key"] != base
+
+    source_digest[0] = "source-one"
+    monkeypatch.setattr(python_diagnostic, "_uv_identity", lambda: "uv 2")
+    assert python_diagnostic.cache_identity("Linux", "X64", "ubuntu24/one", repo_root=tmp_path)["cache_key"] != base
+
+
+def test_verified_wheel_requires_matching_key_name_and_bytes(tmp_path: Path) -> None:
+    wheel = tmp_path / "citry_core-1.2.3-cp314-cp314-any.whl"
+    wheel.write_bytes(b"wheel bytes")
+    python_diagnostic.record_wheel(tmp_path, "exact-key")
+
+    assert python_diagnostic.verified_wheel(tmp_path, "exact-key") == wheel
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["sha256"] == hashlib.sha256(b"wheel bytes").hexdigest()
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        python_diagnostic.verified_wheel(tmp_path, "wrong-key")
+
+    wheel.write_bytes(b"tampered")
+    with pytest.raises(RuntimeError, match="does not match"):
+        python_diagnostic.verified_wheel(tmp_path, "exact-key")
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected_profile_arguments", "needs_core"),
+    [
+        ("citry", ["--package", "citry-monorepo", "--package", "citry"], True),
+        ("citry-core", ["--package", "citry-core"], True),
+        ("citry-lsp", ["--package", "citry-lsp"], True),
+        ("citry-ui", ["--package", "citry-ui"], True),
+        ("pygments-citry", ["--package", "pygments-citry"], False),
+        ("full-workspace", ["--all-packages"], True),
+    ],
+)
+def test_install_profile_narrows_sync_and_substitutes_verified_core_wheel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str,
+    expected_profile_arguments: list[str],
+    needs_core: bool,
+) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(python_diagnostic, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(python_diagnostic, "_executable", lambda name: name)
+    monkeypatch.setattr(
+        python_diagnostic.subprocess,
+        "run",
+        lambda command, **_kwargs: commands.append(command),
+    )
+    if needs_core:
+        wheel = tmp_path / "citry_core.whl"
+        wheel.write_bytes(b"wheel")
+        python_diagnostic.record_wheel(tmp_path, "cache-key")
+
+    python_diagnostic.install_profile(profile, tmp_path, "cache-key")
+
+    expected_sync = ["uv", "sync", "--locked", *expected_profile_arguments]
+    if needs_core:
+        expected_sync.extend(["--no-install-package", "citry-core"])
+    assert commands[0] == expected_sync
+    if needs_core:
+        assert commands[1][:8] == [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            ".venv",
+            "--no-deps",
+            "--reinstall",
+            str(tmp_path / "citry_core.whl"),
+        ]
+        assert commands[2] == [
+            "uv",
+            "run",
+            "--no-sync",
+            "python",
+            "-c",
+            "import citry_core._rust as rust; print(rust.__file__)",
+        ]
+    else:
+        assert len(commands) == 1

--- a/scripts/python_diagnostic.py
+++ b/scripts/python_diagnostic.py
@@ -1,0 +1,333 @@
+"""Validate targets, cache Citry Core wheels, and install dependencies for Python diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WHEEL_CACHE_VERSION: Final = "v1"
+_NATIVE_PATHS: Final = (
+    ".cargo",
+    ".github/workflows/py--diagnostic.yml",
+    "Cargo.lock",
+    "Cargo.toml",
+    "crates",
+    "packages/py/citry_core",
+    "rust-toolchain.toml",
+    "scripts/python_diagnostic.py",
+    "third_party/rust/ruff",
+    "uv.lock",
+)
+_PROFILE_ROOTS: Final = {
+    "citry": (PurePosixPath("packages/py/citry/tests"),),
+    "citry-core": (PurePosixPath("packages/py/citry_core/tests"),),
+    "citry-lsp": (PurePosixPath("packages/py/citry_lsp/tests"),),
+    "citry-ui": (PurePosixPath("packages/py/citry_ui"),),
+    "pygments-citry": (PurePosixPath("packages/py/pygments_citry/tests"),),
+}
+_SYNC_ARGUMENTS: Final = {
+    # Citry owns several repository-policy tests that import root dev tools
+    # such as PyYAML, so its narrow profile selects both owners.
+    "citry": ("--package", "citry-monorepo", "--package", "citry"),
+    "citry-core": ("--package", "citry-core"),
+    "citry-lsp": ("--package", "citry-lsp"),
+    "citry-ui": ("--package", "citry-ui"),
+    "pygments-citry": ("--package", "pygments-citry"),
+    "full-workspace": ("--all-packages",),
+}
+_NO_CORE_PROFILE: Final = "pygments-citry"
+
+
+def _profile_roots(profile: str) -> tuple[PurePosixPath, ...]:
+    if profile == "full-workspace":
+        return tuple(root for roots in _PROFILE_ROOTS.values() for root in roots)
+    try:
+        return _PROFILE_ROOTS[profile]
+    except KeyError as error:
+        msg = f"unknown diagnostic profile: {profile}"
+        raise ValueError(msg) from error
+
+
+def validate_pytest_target(profile: str, target: str, *, repo_root: Path = _REPO_ROOT) -> Path:
+    """Validate one non-browser test file or node ID within the selected profile."""
+    if not target or target.startswith("-") or "\\" in target or any(char in target for char in "\0\r\n"):
+        msg = "pytest target must be one repository-relative POSIX test file or node ID"
+        raise ValueError(msg)
+
+    file_text, separator, node_text = target.partition("::")
+    if separator and (not node_text or any(not part for part in node_text.split("::"))):
+        msg = "pytest node ID segments must not be empty"
+        raise ValueError(msg)
+
+    relative = PurePosixPath(file_text)
+    if relative.is_absolute() or "." in relative.parts or ".." in relative.parts:
+        msg = "pytest target must stay within the selected package"
+        raise ValueError(msg)
+    if relative.suffix != ".py" or not relative.name.startswith("test_"):
+        msg = "pytest target must name a test_*.py file"
+        raise ValueError(msg)
+    if "e2e" in relative.parts or "benchmark" in relative.name:
+        msg = "browser and benchmark tests are outside the diagnostic workflow"
+        raise ValueError(msg)
+    if not any(relative.is_relative_to(root) for root in _profile_roots(profile)):
+        msg = f"pytest target is outside the {profile} diagnostic profile"
+        raise ValueError(msg)
+
+    resolved_root = repo_root.resolve()
+    resolved_target = (resolved_root / Path(*relative.parts)).resolve()
+    if not resolved_target.is_relative_to(resolved_root) or not resolved_target.is_file():
+        msg = "pytest target must be an existing repository file"
+        raise ValueError(msg)
+    return resolved_target
+
+
+def _git_index_records(repo_root: Path) -> bytes:
+    command = [_executable("git"), "ls-files", "--stage", "-z", "--", *_NATIVE_PATHS]
+    result = subprocess.run(command, cwd=repo_root, check=True, capture_output=True)
+    selected = []
+    for record in result.stdout.split(b"\0"):
+        if not record:
+            continue
+        metadata, separator, raw_path = record.partition(b"\t")
+        if not separator:
+            msg = "unexpected Git index record while identifying native inputs"
+            raise RuntimeError(msg)
+        path = PurePosixPath(raw_path.decode("utf-8"))
+        if _is_native_wheel_input(path):
+            selected.append(metadata + separator + raw_path + b"\0")
+    if not selected:
+        msg = "native cache inputs were not found in the Git index"
+        raise RuntimeError(msg)
+    return b"".join(selected)
+
+
+def _is_native_wheel_input(path: PurePosixPath) -> bool:
+    if path.as_posix() in {
+        ".github/workflows/py--diagnostic.yml",
+        "Cargo.lock",
+        "Cargo.toml",
+        "rust-toolchain.toml",
+        "scripts/python_diagnostic.py",
+        "uv.lock",
+    }:
+        return True
+    if path.parts[:1] == (".cargo",):
+        return True
+    if path.as_posix() == "third_party/rust/ruff":
+        return True
+    if path.parts[:1] == ("crates",):
+        return path.name in {"Cargo.toml", "build.rs"} or "src" in path.parts[2:]
+    if path.parts[:3] == ("packages", "py", "citry_core"):
+        return path.name in {"pyproject.toml", "README.md", "LICENSE"} or path.parts[3:4] == ("citry_core",)
+    return False
+
+
+def native_source_digest(*, repo_root: Path = _REPO_ROOT) -> str:
+    """Hash tracked native build inputs, including the Ruff submodule commit."""
+    digest = hashlib.sha256()
+    digest.update(_WHEEL_CACHE_VERSION.encode())
+    digest.update(b"\0")
+    digest.update(_git_index_records(repo_root))
+    return digest.hexdigest()
+
+
+def _rustc_identity() -> tuple[str, str]:
+    result = subprocess.run([_executable("rustc"), "-Vv"], check=True, capture_output=True, text=True)
+    verbose = result.stdout.strip()
+    commit = next(
+        (line.partition(":")[2].strip() for line in verbose.splitlines() if line.startswith("commit-hash:")),
+        "unknown",
+    )
+    return verbose, commit
+
+
+def _uv_identity() -> str:
+    result = subprocess.run([_executable("uv"), "--version"], check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _safe_key_part(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+
+
+def _executable(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        msg = f"required executable is unavailable: {name}"
+        raise RuntimeError(msg)
+    return executable
+
+
+def cache_identity(
+    runner_os: str,
+    runner_arch: str,
+    runner_image: str,
+    *,
+    repo_root: Path = _REPO_ROOT,
+) -> dict[str, str]:
+    """Return the exact native-wheel cache identity for this runner."""
+    rustc_verbose, rustc_commit = _rustc_identity()
+    python_abi = str(sysconfig.get_config_var("SOABI") or sys.implementation.cache_tag)
+    python_runtime = f"{platform.python_implementation()}-{platform.python_version()}-{python_abi}"
+    source_digest = native_source_digest(repo_root=repo_root)
+    uv_version = _uv_identity()
+
+    identity = hashlib.sha256()
+    for value in (runner_os, runner_arch, runner_image, python_runtime, rustc_verbose, uv_version, source_digest):
+        identity.update(value.encode())
+        identity.update(b"\0")
+
+    readable_prefix = "-".join(
+        _safe_key_part(value) for value in (runner_os, runner_arch, sys.implementation.cache_tag or "python")
+    )
+    return {
+        "cache_key": f"diagnostic-citry-core-wheel-{_WHEEL_CACHE_VERSION}-{readable_prefix}-{identity.hexdigest()}",
+        "python_abi": python_abi,
+        "rustc_commit": rustc_commit,
+        "source_digest": source_digest,
+        "uv_version": uv_version,
+    }
+
+
+def _one_wheel(wheel_dir: Path) -> Path:
+    wheels = sorted(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        msg = f"expected exactly one cached citry-core wheel, found {len(wheels)}"
+        raise RuntimeError(msg)
+    return wheels[0]
+
+
+def record_wheel(wheel_dir: Path, cache_key: str) -> Path:
+    """Record the cache identity and wheel digest beside a newly built wheel."""
+    wheel = _one_wheel(wheel_dir)
+    manifest = {
+        "cache_key": cache_key,
+        "sha256": hashlib.sha256(wheel.read_bytes()).hexdigest(),
+        "wheel": wheel.name,
+    }
+    (wheel_dir / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return wheel
+
+
+def verified_wheel(wheel_dir: Path, expected_cache_key: str) -> Path:
+    """Reject incomplete, misplaced, or modified wheel-cache contents."""
+    wheel = _one_wheel(wheel_dir)
+    manifest_path = wheel_dir / "manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        msg = "cached citry-core wheel has no valid manifest"
+        raise RuntimeError(msg) from error
+    expected_digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+    if manifest != {"cache_key": expected_cache_key, "sha256": expected_digest, "wheel": wheel.name}:
+        msg = "cached citry-core wheel does not match its cache identity or digest"
+        raise RuntimeError(msg)
+    return wheel
+
+
+def install_profile(profile: str, wheel_dir: Path, expected_cache_key: str) -> None:
+    """Install only the selected package's test environment and its exact Core wheel."""
+    try:
+        profile_arguments = _SYNC_ARGUMENTS[profile]
+    except KeyError as error:
+        msg = f"unknown diagnostic profile: {profile}"
+        raise ValueError(msg) from error
+
+    sync_command = [_executable("uv"), "sync", "--locked", *profile_arguments]
+    if profile != _NO_CORE_PROFILE:
+        sync_command.extend(("--no-install-package", "citry-core"))
+    subprocess.run(sync_command, cwd=_REPO_ROOT, check=True)
+
+    if profile != _NO_CORE_PROFILE:
+        wheel = verified_wheel(wheel_dir, expected_cache_key)
+        install_command = [
+            _executable("uv"),
+            "pip",
+            "install",
+            "--python",
+            ".venv",
+            "--no-deps",
+            "--reinstall",
+            str(wheel),
+        ]
+        subprocess.run(install_command, cwd=_REPO_ROOT, check=True)
+        # Loading the extension catches incompatible or incomplete wheels before
+        # the workflow saves an immutable entry under the exact cache key.
+        smoke_command = [
+            _executable("uv"),
+            "run",
+            "--no-sync",
+            "python",
+            "-c",
+            "import citry_core._rust as rust; print(rust.__file__)",
+        ]
+        subprocess.run(smoke_command, cwd=_REPO_ROOT, check=True)
+
+
+def _write_github_outputs(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            if "\n" in value or "\r" in value:
+                msg = f"GitHub output {key} must fit on one line"
+                raise ValueError(msg)
+            output.write(f"{key}={value}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-target")
+    validate.add_argument("--profile", required=True, choices=tuple(_SYNC_ARGUMENTS))
+    validate.add_argument("--target", required=True)
+
+    identity = subparsers.add_parser("cache-identity")
+    identity.add_argument("--runner-os", required=True)
+    identity.add_argument("--runner-arch", required=True)
+    identity.add_argument("--runner-image", required=True)
+    identity.add_argument("--github-output", required=True, type=Path)
+
+    record = subparsers.add_parser("record-wheel")
+    record.add_argument("--wheel-dir", required=True, type=Path)
+    record.add_argument("--cache-key", required=True)
+
+    install = subparsers.add_parser("install-profile")
+    install.add_argument("--profile", required=True, choices=tuple(_SYNC_ARGUMENTS))
+    install.add_argument("--wheel-dir", required=True, type=Path)
+    install.add_argument("--cache-key", default="")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.command == "validate-target":
+        path = validate_pytest_target(args.profile, args.target)
+        sys.stdout.write(f"Validated diagnostic target: {path.relative_to(_REPO_ROOT)}\n")
+    elif args.command == "cache-identity":
+        values = cache_identity(args.runner_os, args.runner_arch, args.runner_image)
+        _write_github_outputs(args.github_output, values)
+        sys.stdout.write(
+            "Citry Core wheel identity: "
+            f"Python ABI {values['python_abi']}, rustc {values['rustc_commit'][:12]}, "
+            f"{values['uv_version']}, sources {values['source_digest'][:12]}\n"
+        )
+    elif args.command == "record-wheel":
+        wheel = record_wheel(args.wheel_dir, args.cache_key)
+        sys.stdout.write(f"Recorded Citry Core wheel: {wheel.name}\n")
+    elif args.command == "install-profile":
+        install_profile(args.profile, args.wheel_dir, args.cache_key)
+        sys.stdout.write(f"Installed diagnostic profile: {args.profile}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Python diagnostics currently spend most of their feedback time rebuilding and installing the full workspace before one selected test can run. This change gives the manual diagnostic workflow package-specific install profiles and reuses an exact, verified `citry_core` wheel when native inputs have not changed.

On an exact cache hit, the workflow skips submodule initialization and native compilation. On a miss, it builds through GitHub-backed `sccache`, verifies and imports the wheel, and saves it before pytest so a failing diagnostic still seeds the next attempt. Cache identity covers the hosted image, OS/architecture, Python ABI/runtime, actual Rust and uv versions, native sources, lockfiles, package inputs, and the build recipe. A forced-rebuild mode and full-workspace profile remain available.

Validation:
- 26 focused workflow/helper tests
- Ruff and mypy
- all 27 workflow YAML files parsed
- real narrowed Citry profile exercised against a repository-policy test
- independent technical and prose review

No package versions or release configuration change.
